### PR TITLE
Add minMQ to CoverageCalculator/BamWindow/CovCalcApp. Add dbsnp use to GATK IndelRealigner

### DIFF
--- a/src/main/java/util/coverage/CovCalcApp.java
+++ b/src/main/java/util/coverage/CovCalcApp.java
@@ -24,6 +24,7 @@ import buffer.IntervalsFile;
  *
  */
 public class CovCalcApp {
+	private static int minMQ = 0;
 	
 	static class CovRunner implements Runnable {
 		
@@ -52,7 +53,7 @@ public class CovCalcApp {
 			CoverageCalculator covCalc;
 			try {
 				System.err.println("Beginning execution for "+ inputBam.getName());
-				covCalc = new CoverageCalculator(inputBam, intervals);
+				covCalc = new CoverageCalculator(inputBam, intervals, minMQ);
 				sampleResults = covCalc.computeCoverageByInterval();
 				
 				double totalExtent = 0;
@@ -125,8 +126,9 @@ public class CovCalcApp {
 		
 		if (args.length==0 || args[0].startsWith("-h")) {
 			System.err.println("Coverage Calculator utility, v0.03");
-			System.err.println("\n Usage: java -jar [bed file] [bam file] [more bam files...] [-t/--threads numThreads] [-f/--format outputFormat].");
+			System.err.println("\n Usage: java -jar [bed file] [bam file] [more bam files...] [-t/--threads numThreads] [-f/--format outputFormat] [-m/--minMQ minimumMappingQuality].");
 			System.err.println("If -t/--threads flag is used, it overrides the default number of threads " + DEFAULT_THREADS + ".");
+			System.err.println("-m/--minMQ sets a minimum mapping quality for read inclusion in coverage calculations.");
 			System.err.println("Setting -f/--format to 'bed', overrides the default format used (interval).");
 			System.err.println("\n Emits mean depth of coverage for all intervals in BED file to output.");
 			return;
@@ -162,6 +164,10 @@ public class CovCalcApp {
 					}
 				}
 			}
+			if(args[i].startsWith("--minMQ") || args[i].equals("-m")){
+				i++;
+				minMQ = Integer.parseInt(args[i]);
+			}
 		}
 		/*
 		for(int i = 0; i < args.length; i++){
@@ -191,7 +197,11 @@ public class CovCalcApp {
 				i++;
 				continue;  // Step over two - both the flag and the value.
 			}
-			else if (args[i].startsWith("--format")){
+			else if (args[i].startsWith("--format") || args[i].equals("-f")){
+				i++;
+				continue;
+			}
+			else if (args[i].startsWith("--minMQ") || args[i].equals("-m")){
 				i++;
 				continue;
 			}

--- a/src/main/java/util/coverage/CoverageCalculator.java
+++ b/src/main/java/util/coverage/CoverageCalculator.java
@@ -30,6 +30,7 @@ public class CoverageCalculator {
 	protected File inputBam = null;
 	protected HasIntervals intervals;
 	private int threads = Math.max(1, Runtime.getRuntime().availableProcessors()/2);
+	private int minMQ = 0;
 	
 	/**
 	 * Creates a new CoverageCalculator object that will examine the given BAM file over
@@ -41,6 +42,19 @@ public class CoverageCalculator {
 	public CoverageCalculator(File inputBam, HasIntervals intervals) throws IOException {
 		this.inputBam = inputBam;
 		this.intervals = intervals;
+	}
+	
+	/**
+	 * Creates a new CoverageCalculator object that will examine the given BAM file over
+	 * the given set of intervals, requiring a minimum Mapping Quality.
+	 * @param inputBam
+	 * @param intervals
+	 * @throws IOException
+	 */
+	public CoverageCalculator(File inputBam, HasIntervals intervals, int minMQ) throws IOException {
+		this.inputBam = inputBam;
+		this.intervals = intervals;
+		this.minMQ = minMQ;
 	}
 
 	/**
@@ -308,7 +322,7 @@ public class CoverageCalculator {
 		public void run() {
 			intervalResults = new ArrayList<IntervalCovSummary>();
 			try {
-				BamWindow window = new BamWindow(inputBam);
+				BamWindow window = new BamWindow(inputBam, minMQ);
 				
 				for(Interval interval : subIntervals) {
 					CovResult result = CoverageCalculator.calculateDepthHistogram(window, chr, interval.begin, interval.end, depths);


### PR DESCRIPTION
Expanded BamWindow to permit specification of a minimum mapping quality.

Excluded reads where mates aligned to different contigs or were unmapped from insert size calculations for BamWindow's function.

Added this minimum mapping quality parameter to CoverageCalculator and to the command line tool for calling it.

Tested the coverage calculator at least, which still works. I haven't tested the GATK call change, though I believe that adding " -known $dbsnpPath " should work perfectly fine. This will change default behavior, though, as it looks for the same key as the DBSNP annotator and would therefore always find a path to dbsnp for any pipeline, since it's still in the Pipeline Properties xml.