### PR TITLE
Bug snpeff preferred NMs

### DIFF
--- a/src/main/java/operator/Operator.java
+++ b/src/main/java/operator/Operator.java
@@ -299,6 +299,20 @@ public abstract class Operator extends PipelineObject {
 		return preferredNMs;		
 	}
 
+	protected Map<String, String> getSpecificPreferredNMs(String nmsFilePath) throws IOException {
+		Map<String, String> preferredNMs = new HashMap<String,String>();
+		//Now load the specific nms for this operator
+		if (nmsFilePath != null) {
+			File specificNMFile = new File(nmsFilePath);
+			Logger.getLogger(Pipeline.primaryLoggerName).info("Running getSpecificPreferredNMs on preferred NM list: " + nmsFilePath);
+			Map<String, String> specificNMs = readNMFile(specificNMFile);
+
+			for(String key : specificNMs.keySet()) {
+				preferredNMs.put(key, specificNMs.get(key));
+			}
+		}
+		return preferredNMs;
+	}
 	
 	private static Map<String, String> readNMFile(File file) throws IOException {
 		Map<String, String> nms = new HashMap<String,String>();

--- a/src/main/java/operator/snpeff/SnpEffGeneAnnotate.java
+++ b/src/main/java/operator/snpeff/SnpEffGeneAnnotate.java
@@ -176,7 +176,6 @@ public class SnpEffGeneAnnotate extends Annotator {
 		SnpEffInfo topHit = infoList.get(0);
 		int topRank = calculateRank(topHit.changeType);
 		for(SnpEffInfo info : infoList) {
-			
 			int infoRank= calculateRank(info.changeType);
 			
 			//First check to see if it's in the nmMap. If so, it gets a really high rank
@@ -192,6 +191,20 @@ public class SnpEffGeneAnnotate extends Annotator {
 			if (infoRank > topRank) {
 				topHit = info;
 				topRank = infoRank;
+			} else if (infoRank == topRank) { //We have a tie breaker and need to make sure the gene in the specificied preferred list wins.
+				try {
+					String specificNMFile = this.getAttribute(NM_DEFS);
+					if (specificNMFile!=null) {
+						if (this.getSpecificPreferredNMs(this.getAttribute(NM_DEFS)).containsKey(info.gene)) {
+							topHit = info;
+							topRank = infoRank;
+						}
+					}
+
+				} catch (IOException e) {
+					e.printStackTrace();
+					throw new IllegalArgumentException("Could not read NMs file:  " + this.getAttribute(NM_DEFS));
+				}
 			}
 		}
 
@@ -498,7 +511,6 @@ public class SnpEffGeneAnnotate extends Annotator {
 			e.printStackTrace();
 			throw new IllegalArgumentException("Could not read NMs file:  " +nmDefs);
 		}
-		
 	}
 	
 	

--- a/src/main/java/pipeline/Pipeline.java
+++ b/src/main/java/pipeline/Pipeline.java
@@ -49,7 +49,7 @@ import util.text.QueuedLogHandler;
  */
 public class Pipeline {
 
-	public static final String PIPELINE_VERSION = "1.6";
+	public static final String PIPELINE_VERSION = "1.7";
 	protected File source;
 	protected Document xmlDoc;
 	public static final String PROJECT_HOME="home";


### PR DESCRIPTION
Added some logic to check the preferred NM list if there is a tie breaker situation and to allow the preferred NM list genes to be used to annotate the variants. Still not the best solution I feel like. Jacob, I wanted to merge this with your branch because you have been working on this and this may or may not be an issue after your changes. Please look this over and we can discuss it.