### PR TITLE
Modified ExAC63K annotator nix

### DIFF
--- a/src/main/java/buffer/variant/VariantRec.java
+++ b/src/main/java/buffer/variant/VariantRec.java
@@ -883,12 +883,6 @@ public class VariantRec {
 	public static final String EXAC63K_VERSION = "exac63k.version";
 	
 	//overall
-	
-	//modified by Nix
-	//public static final String EXAC63K_OVERALL_FREQ_HET = "exomes63K.al.freq.het";
-	//public static final String EXAC63K_OVERALL_FREQ_HOM = "exomes63K.al.freq.hom";
-	//public static final String EXAC63K_OVERALL_FREQ_HEMI = "exomes63K.al.freq.hemi";
-	
 	public static final String EXAC63K_OVERALL_FREQ_HET = "exac63K.overall.het.freq";
 	public static final String EXAC63K_OVERALL_FREQ_HOM = "exac63K.overall.hom.freq";
 	public static final String EXAC63K_OVERALL_FREQ_HEMI = "exac63K.overall.hemi.freq";

--- a/src/main/java/buffer/variant/VariantRec.java
+++ b/src/main/java/buffer/variant/VariantRec.java
@@ -879,16 +879,19 @@ public class VariantRec {
 	//added for IonTorrentParser
 	public static final String VAR_FREQ = "Var.Freq";
 
-	
-	
-	public static final String EXAC63K_OVERALL_FREQ_HET = "exomes63K.al.freq.het";
-	public static final String EXAC63K_OVERALL_FREQ_HOM = "exomes63K.al.freq.hom";
-	public static final String EXAC63K_OVERALL_FREQ_HEMI = "exomes63K.al.freq.hemi";
-
 	//ExAC annotations
 	public static final String EXAC63K_VERSION = "exac63k.version";
 	
 	//overall
+	
+	//modified by Nix
+	//public static final String EXAC63K_OVERALL_FREQ_HET = "exomes63K.al.freq.het";
+	//public static final String EXAC63K_OVERALL_FREQ_HOM = "exomes63K.al.freq.hom";
+	//public static final String EXAC63K_OVERALL_FREQ_HEMI = "exomes63K.al.freq.hemi";
+	
+	public static final String EXAC63K_OVERALL_FREQ_HET = "exac63K.overall.het.freq";
+	public static final String EXAC63K_OVERALL_FREQ_HOM = "exac63K.overall.hom.freq";
+	public static final String EXAC63K_OVERALL_FREQ_HEMI = "exac63K.overall.hemi.freq";
 	public static final String EXAC63K_OVERALL_ALLELE_COUNT = "exac63k.overall.allele.count";
 	public static final String EXAC63K_OVERALL_ALLELE_NUMBER = "exac63k.overall.allele.number";
 	public static final String EXAC63K_OVERALL_HOM_COUNT = "exac63k.overall.hom.count";

--- a/src/main/java/disease/OMIMDB.java
+++ b/src/main/java/disease/OMIMDB.java
@@ -142,7 +142,7 @@ public class OMIMDB {
 				entryCount++;
 			}
 			else {
-				System.out.println("Skipping entry " + diseaseStr + ", could not parse phenotype id");
+				System.out.println("Skipping entry " + diseaseStr + ", could not parse phenotype id from "+line);
 			}
 			line = reader.readLine();
 		}

--- a/src/main/java/operator/qc/QCtoJSON.java
+++ b/src/main/java/operator/qc/QCtoJSON.java
@@ -330,7 +330,7 @@ public class QCtoJSON extends Operator {
 		VariantPool novels= new VariantPool();
 		for(String contig : vp.getContigs()) {
 			for(VariantRec var : vp.getVariantsForContig(contig)) {
-				System.out.println("var: "+var.getContig()+" "+var.getStart()+" "+var.getRef()+" "+var.getAlt());
+				//System.out.println("var: "+var.getContig()+" "+var.getStart()+" "+var.getRef()+" "+var.getAlt());
 				Double tgpFreq = var.getProperty(VariantRec.POP_FREQUENCY);
 				Double espFreq = var.getProperty(VariantRec.EXOMES_FREQ);
 				Double mmFreq = var.getProperty(VariantRec.MITOMAP_FREQ);//for MDNA tests

--- a/src/main/java/operator/variant/DBNSFPAnnotator.java
+++ b/src/main/java/operator/variant/DBNSFPAnnotator.java
@@ -411,7 +411,7 @@ public class DBNSFPAnnotator extends AbstractTabixAnnotator {
         try {
             if (toks[sift_score_col].contains(";")) {
                 String[] values = toks[sift_score_col].split(";");
-                System.out.println(sift_score_col);
+                //System.out.println(sift_score_col);
                 double lowest = 2.0;
                 for (String i : values) {
                     try {

--- a/src/main/java/operator/variant/ExAC63KExomesAnnotator.java
+++ b/src/main/java/operator/variant/ExAC63KExomesAnnotator.java
@@ -2,36 +2,52 @@ package operator.variant;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
+import org.w3c.dom.NodeList;
 import buffer.variant.VariantRec;
 import operator.OperationFailedException;
+
 
 /**
  * Provides several 63K Exomes-based annotations from
  * a tabix-indexed "sites" file usually downloaded directly from : 
  * ftp://ftp.broadinstitute.org/pub/ExAC_release/release0.2/ExAC.r0.2.sites.vep.vcf.gz
  * to produce the annotations.
- * Release 0.2
+ * Release 0.3
  * This new version extends from AbstractTabixAnnotator, which handles initialization of the tabix reader,
  * normalizaton of the variants, and some error checking. 
  * 
- * @author daniel
+ * @author daniel, Nix
+ * 
+ * Nix added ability to truncate output to just overall.
  *
  */
 public class ExAC63KExomesAnnotator extends AbstractTabixAnnotator {
 
 	public static final String EXAC_63K_PATH = "63k.db.path";
-	
+	private static final String JUST_LOAD_OVERALL = "justLoadOverall";
+	public boolean justLoadOverall = false;
+
+	public void initialize(NodeList children) {
+		super.initialize(children);
+
+		//see if they just want overall info
+		if (properties.containsKey(JUST_LOAD_OVERALL)) {
+			String test = properties.get(JUST_LOAD_OVERALL).toLowerCase();
+			if (test.equals("true")) justLoadOverall = true;
+			else justLoadOverall = false;
+		}
+	}
+
 	@Override
 	protected String getPathToTabixedFile() {
 		return searchForAttribute(EXAC_63K_PATH);
 	}
-	
+
 	private boolean safeParseAndSetProperty(VariantRec var, String propertyKey, String valToParse, Double divisor) {
 		if (valToParse==null) {
 			return false;
 		}
-		
+
 		try {
 			Double freq = Double.parseDouble(valToParse)/divisor;
 			if(!freq.equals(Double.NaN)) {
@@ -41,26 +57,26 @@ public class ExAC63KExomesAnnotator extends AbstractTabixAnnotator {
 			//Don't worry about it, just don't set the property
 			return false;
 		}
-		
+
 		return true;
 	}
-	
+
 	private boolean safeSetCalcFreq(VariantRec var, String  propertyKey, String alleleCount, String alleleNumber) {
 		if (alleleCount==null || alleleNumber==null) {
 			return false;
 		}
-		
+
 		try {
 			Double freq = Double.parseDouble(alleleCount)/Double.parseDouble(alleleNumber);
 			if(!freq.equals(Double.NaN)) {
 				Double finalFreq = Math.round( freq * 10000.0 ) / 10000.0;
-				var.addProperty(propertyKey, finalFreq);
+				var.addProperty(propertyKey, finalFreq);				
 			}
 		} catch (NumberFormatException nfe) {
 			//Don't worry about it, just don't set the property
 			return false;
 		}
-		
+
 		return true;
 	}
 	/**
@@ -75,18 +91,17 @@ public class ExAC63KExomesAnnotator extends AbstractTabixAnnotator {
 		String[] toks = str.split("\t");
 		//The 7th column is the info column, which looks a little like AF=0.23;AF_AMR=0.123;AF_EUR=0.456...
 		String[] infoToks = toks[7].split(";");
-	
+
 		String overallAlleleCount = valueForKeyAtIndex(infoToks, "AC_Adj", altIndex);
 		String overallAlleleNumber = valueForKey(infoToks, "AN_Adj");
 
 		Path p = Paths.get(searchForAttribute(EXAC_63K_PATH));
 		String exacVersion = p.getFileName().toString().replace(".sites.vep.vcf.gz", "");
-		var.addAnnotation(VariantRec.EXAC63K_VERSION, exacVersion);
-		
-		//exomes63K.al.freq.het, exomes63K.al.freq.hom
+		if (justLoadOverall == false) var.addAnnotation(VariantRec.EXAC63K_VERSION, exacVersion);
+
 		//AC_Het / totalAlleles
 		safeSetCalcFreq(var, VariantRec.EXAC63K_OVERALL_FREQ_HET, valueForKeyAtIndex(infoToks, "AC_Het", altIndex), overallAlleleNumber);
-		
+
 		//AC_Hom * 2 / totalAlleles
 		String homAlleleNum = String.valueOf(Double.valueOf(valueForKeyAtIndex(infoToks, "AC_Hom", altIndex)) * 2.0 );
 		safeSetCalcFreq(var, VariantRec.EXAC63K_OVERALL_FREQ_HOM, homAlleleNum, overallAlleleNumber);
@@ -97,85 +112,83 @@ public class ExAC63KExomesAnnotator extends AbstractTabixAnnotator {
 		safeParseAndSetProperty(var, VariantRec.EXAC63K_OVERALL_HOM_COUNT, valueForKeyAtIndex(infoToks, "AC_Hom", altIndex), 1.0);
 		safeSetCalcFreq(var, VariantRec.EXAC63K_OVERALL_ALLELE_FREQ, overallAlleleCount, overallAlleleNumber);
 		
-		//African
-		String africanAlleleCount = valueForKeyAtIndex(infoToks, "AC_AFR", altIndex);
-		String africanAlleleNumber = valueForKey(infoToks, "AN_AFR");
-		safeParseAndSetProperty(var, VariantRec.EXAC63K_AFRICAN_ALLELE_COUNT, africanAlleleCount, 1.0);
-		safeParseAndSetProperty(var, VariantRec.EXAC63K_AFRICAN_ALLELE_NUMBER, africanAlleleNumber, 1.0);
-		safeParseAndSetProperty(var, VariantRec.EXAC63K_AFRICAN_HOM_COUNT, valueForKeyAtIndex(infoToks, "Hom_AFR", altIndex), 1.0);
-		safeSetCalcFreq(var, VariantRec.EXAC63K_AFRICAN_ALLELE_FREQ, africanAlleleCount, africanAlleleNumber);
+		//add breakdowns?
+		if (justLoadOverall == false) {
 
+			//African
+			String africanAlleleCount = valueForKeyAtIndex(infoToks, "AC_AFR", altIndex);
+			String africanAlleleNumber = valueForKey(infoToks, "AN_AFR");
+			safeParseAndSetProperty(var, VariantRec.EXAC63K_AFRICAN_ALLELE_COUNT, africanAlleleCount, 1.0);
+			safeParseAndSetProperty(var, VariantRec.EXAC63K_AFRICAN_ALLELE_NUMBER, africanAlleleNumber, 1.0);
+			safeParseAndSetProperty(var, VariantRec.EXAC63K_AFRICAN_HOM_COUNT, valueForKeyAtIndex(infoToks, "Hom_AFR", altIndex), 1.0);
+			safeSetCalcFreq(var, VariantRec.EXAC63K_AFRICAN_ALLELE_FREQ, africanAlleleCount, africanAlleleNumber);
 
-		//Latino
-		String latinoAlleleCount = valueForKeyAtIndex(infoToks, "AC_AMR", altIndex);
-		String latinoAlleleNumber = valueForKey(infoToks, "AN_AMR");
-		safeParseAndSetProperty(var, VariantRec.EXAC63K_LATINO_ALLELE_COUNT, latinoAlleleCount, 1.0);
-		safeParseAndSetProperty(var, VariantRec.EXAC63K_LATINO_ALLELE_NUMBER, latinoAlleleNumber, 1.0);
-		safeParseAndSetProperty(var, VariantRec.EXAC63K_LATINO_HOM_COUNT, valueForKeyAtIndex(infoToks, "Hom_AMR", altIndex), 1.0);
-		safeSetCalcFreq(var, VariantRec.EXAC63K_LATINO_ALLELE_FREQ, latinoAlleleCount, latinoAlleleNumber);
+			//Latino
+			String latinoAlleleCount = valueForKeyAtIndex(infoToks, "AC_AMR", altIndex);
+			String latinoAlleleNumber = valueForKey(infoToks, "AN_AMR");
+			safeParseAndSetProperty(var, VariantRec.EXAC63K_LATINO_ALLELE_COUNT, latinoAlleleCount, 1.0);
+			safeParseAndSetProperty(var, VariantRec.EXAC63K_LATINO_ALLELE_NUMBER, latinoAlleleNumber, 1.0);
+			safeParseAndSetProperty(var, VariantRec.EXAC63K_LATINO_HOM_COUNT, valueForKeyAtIndex(infoToks, "Hom_AMR", altIndex), 1.0);
+			safeSetCalcFreq(var, VariantRec.EXAC63K_LATINO_ALLELE_FREQ, latinoAlleleCount, latinoAlleleNumber);
 
+			//East Asian
+			String eastAsianAlleleCount = valueForKeyAtIndex(infoToks, "AC_EAS", altIndex);
+			String eastAsianAlleleNumber = valueForKey(infoToks, "AN_EAS");
+			safeParseAndSetProperty(var, VariantRec.EXAC63K_EASTASIAN_ALLELE_COUNT, eastAsianAlleleCount, 1.0);
+			safeParseAndSetProperty(var, VariantRec.EXAC63K_EASTASIAN_ALLELE_NUMBER, eastAsianAlleleNumber, 1.0);
+			safeParseAndSetProperty(var, VariantRec.EXAC63K_EASTASIAN_HOM_COUNT, valueForKeyAtIndex(infoToks, "Hom_EAS", altIndex), 1.0);
+			safeSetCalcFreq(var, VariantRec.EXAC63K_EASTASIAN_ALLELE_FREQ, eastAsianAlleleCount, eastAsianAlleleNumber);
 
-		//East Asian
-		String eastAsianAlleleCount = valueForKeyAtIndex(infoToks, "AC_EAS", altIndex);
-		String eastAsianAlleleNumber = valueForKey(infoToks, "AN_EAS");
-		safeParseAndSetProperty(var, VariantRec.EXAC63K_EASTASIAN_ALLELE_COUNT, eastAsianAlleleCount, 1.0);
-		safeParseAndSetProperty(var, VariantRec.EXAC63K_EASTASIAN_ALLELE_NUMBER, eastAsianAlleleNumber, 1.0);
-		safeParseAndSetProperty(var, VariantRec.EXAC63K_EASTASIAN_HOM_COUNT, valueForKeyAtIndex(infoToks, "Hom_EAS", altIndex), 1.0);
-		safeSetCalcFreq(var, VariantRec.EXAC63K_EASTASIAN_ALLELE_FREQ, eastAsianAlleleCount, eastAsianAlleleNumber);
+			//Finnish
+			String finnishAlleleCount = valueForKeyAtIndex(infoToks, "AC_FIN", altIndex);
+			String finnishAlleleNumber = valueForKey(infoToks, "AN_FIN");
+			safeParseAndSetProperty(var, VariantRec.EXAC63K_EUR_FINNISH_ALLELE_COUNT, finnishAlleleCount, 1.0);
+			safeParseAndSetProperty(var, VariantRec.EXAC63K_EUR_FINNISH_ALLELE_NUMBER, finnishAlleleNumber, 1.0);
+			safeParseAndSetProperty(var, VariantRec.EXAC63K_EUR_FINNISH_HOM_COUNT, valueForKeyAtIndex(infoToks, "Hom_FIN", altIndex), 1.0);
+			safeSetCalcFreq(var, VariantRec.EXAC63K_EUR_FINNISH_ALLELE_FREQ, finnishAlleleCount, finnishAlleleNumber);
 
+			//Non-Finnish Europeans
+			String europeanAlleleCount = valueForKeyAtIndex(infoToks, "AC_NFE", altIndex);
+			String europeanAlleleNumber = valueForKey(infoToks, "AN_NFE");
+			safeParseAndSetProperty(var, VariantRec.EXAC63K_EUR_NONFINNISH_ALLELE_COUNT, europeanAlleleCount, 1.0);
+			safeParseAndSetProperty(var, VariantRec.EXAC63K_EUR_NONFINNISH_ALLELE_NUMBER, europeanAlleleNumber, 1.0);
+			safeParseAndSetProperty(var, VariantRec.EXAC63K_EUR_NONFINNISH_HOM_COUNT, valueForKeyAtIndex(infoToks, "Hom_NFE", altIndex), 1.0);
+			safeSetCalcFreq(var, VariantRec.EXAC63K_EUR_NONFINNISH_ALLELE_FREQ, europeanAlleleCount, europeanAlleleNumber);
 
+			//South Asian
+			String southAsianAlleleCount = valueForKeyAtIndex(infoToks, "AC_SAS", altIndex);
+			String southAsianAlleleNumber = valueForKey(infoToks, "AN_SAS");
+			safeParseAndSetProperty(var, VariantRec.EXAC63K_SOUTHASIAN_ALLELE_COUNT, southAsianAlleleCount, 1.0);
+			safeParseAndSetProperty(var, VariantRec.EXAC63K_SOUTHASIAN_ALLELE_NUMBER, southAsianAlleleNumber, 1.0);
+			safeParseAndSetProperty(var, VariantRec.EXAC63K_SOUTHASIAN_HOM_COUNT, valueForKeyAtIndex(infoToks, "Hom_SAS", altIndex), 1.0);
+			safeSetCalcFreq(var, VariantRec.EXAC63K_SOUTHASIAN_ALLELE_FREQ, southAsianAlleleCount, southAsianAlleleNumber);
 
-		//Finnish
-		String finnishAlleleCount = valueForKeyAtIndex(infoToks, "AC_FIN", altIndex);
-		String finnishAlleleNumber = valueForKey(infoToks, "AN_FIN");
-		safeParseAndSetProperty(var, VariantRec.EXAC63K_EUR_FINNISH_ALLELE_COUNT, finnishAlleleCount, 1.0);
-		safeParseAndSetProperty(var, VariantRec.EXAC63K_EUR_FINNISH_ALLELE_NUMBER, finnishAlleleNumber, 1.0);
-		safeParseAndSetProperty(var, VariantRec.EXAC63K_EUR_FINNISH_HOM_COUNT, valueForKeyAtIndex(infoToks, "Hom_FIN", altIndex), 1.0);
-		safeSetCalcFreq(var, VariantRec.EXAC63K_EUR_FINNISH_ALLELE_FREQ, finnishAlleleCount, finnishAlleleNumber);
-	
-	
-		//Non-Finnish Europeans
-		String europeanAlleleCount = valueForKeyAtIndex(infoToks, "AC_NFE", altIndex);
-		String europeanAlleleNumber = valueForKey(infoToks, "AN_NFE");
-		safeParseAndSetProperty(var, VariantRec.EXAC63K_EUR_NONFINNISH_ALLELE_COUNT, europeanAlleleCount, 1.0);
-		safeParseAndSetProperty(var, VariantRec.EXAC63K_EUR_NONFINNISH_ALLELE_NUMBER, europeanAlleleNumber, 1.0);
-		safeParseAndSetProperty(var, VariantRec.EXAC63K_EUR_NONFINNISH_HOM_COUNT, valueForKeyAtIndex(infoToks, "Hom_NFE", altIndex), 1.0);
-		safeSetCalcFreq(var, VariantRec.EXAC63K_EUR_NONFINNISH_ALLELE_FREQ, europeanAlleleCount, europeanAlleleNumber);
+			//Other populations
+			String otherAlleleCount = valueForKeyAtIndex(infoToks, "AC_OTH", altIndex);
+			String otherAlleleNumber = valueForKey(infoToks, "AN_OTH");
+			safeParseAndSetProperty(var, VariantRec.EXAC63K_OTHER_ALLELE_COUNT, otherAlleleCount, 1.0);
+			safeParseAndSetProperty(var, VariantRec.EXAC63K_OTHER_ALLELE_NUMBER, otherAlleleNumber, 1.0);
+			safeParseAndSetProperty(var, VariantRec.EXAC63K_OTHER_HOM_COUNT, valueForKeyAtIndex(infoToks, "Hom_OTH", altIndex), 1.0);
+			safeSetCalcFreq(var, VariantRec.EXAC63K_OTHER_ALLELE_FREQ, otherAlleleCount, otherAlleleNumber);
+		}
 
-
-		//South Asian
-		String southAsianAlleleCount = valueForKeyAtIndex(infoToks, "AC_SAS", altIndex);
-		String southAsianAlleleNumber = valueForKey(infoToks, "AN_SAS");
-		safeParseAndSetProperty(var, VariantRec.EXAC63K_SOUTHASIAN_ALLELE_COUNT, southAsianAlleleCount, 1.0);
-		safeParseAndSetProperty(var, VariantRec.EXAC63K_SOUTHASIAN_ALLELE_NUMBER, southAsianAlleleNumber, 1.0);
-		safeParseAndSetProperty(var, VariantRec.EXAC63K_SOUTHASIAN_HOM_COUNT, valueForKeyAtIndex(infoToks, "Hom_SAS", altIndex), 1.0);
-		safeSetCalcFreq(var, VariantRec.EXAC63K_SOUTHASIAN_ALLELE_FREQ, southAsianAlleleCount, southAsianAlleleNumber);
-
-
-		//Other populations
-		String otherAlleleCount = valueForKeyAtIndex(infoToks, "AC_OTH", altIndex);
-		String otherAlleleNumber = valueForKey(infoToks, "AN_OTH");
-		safeParseAndSetProperty(var, VariantRec.EXAC63K_OTHER_ALLELE_COUNT, otherAlleleCount, 1.0);
-		safeParseAndSetProperty(var, VariantRec.EXAC63K_OTHER_ALLELE_NUMBER, otherAlleleNumber, 1.0);
-		safeParseAndSetProperty(var, VariantRec.EXAC63K_OTHER_HOM_COUNT, valueForKeyAtIndex(infoToks, "Hom_OTH", altIndex), 1.0);
-		safeSetCalcFreq(var, VariantRec.EXAC63K_OTHER_ALLELE_FREQ, otherAlleleCount, otherAlleleNumber);
-		
 		//We should also check if it is on the X chrom, and add hemi info..
 		if (str.contains("AC_Hemi")) { //Has hemi info.
 			safeSetCalcFreq(var, VariantRec.EXAC63K_OVERALL_FREQ_HEMI, valueForKeyAtIndex(infoToks, "AC_Hemi", altIndex), overallAlleleNumber);
-			
 			safeParseAndSetProperty(var, VariantRec.EXAC63K_OVERALL_HEMI_COUNT, valueForKeyAtIndex(infoToks, "AC_Hemi", altIndex), 1.0);
-			
-			//populations
-			safeParseAndSetProperty(var, VariantRec.EXAC63K_AFRICAN_HEMI_COUNT, valueForKeyAtIndex(infoToks, "Hemi_AFR", altIndex), 1.0);
-			safeParseAndSetProperty(var, VariantRec.EXAC63K_LATINO_HEMI_COUNT, valueForKeyAtIndex(infoToks, "Hemi_AMR", altIndex), 1.0);
-			safeParseAndSetProperty(var, VariantRec.EXAC63K_EASTASIAN_HEMI_COUNT, valueForKeyAtIndex(infoToks, "Hemi_EAS", altIndex), 1.0);
-			safeParseAndSetProperty(var, VariantRec.EXAC63K_EUR_FINNISH_HEMI_COUNT, valueForKeyAtIndex(infoToks, "Hemi_FIN", altIndex), 1.0);
-			safeParseAndSetProperty(var, VariantRec.EXAC63K_EUR_NONFINNISH_HEMI_COUNT, valueForKeyAtIndex(infoToks, "Hemi_NFE", altIndex), 1.0);
-			safeParseAndSetProperty(var, VariantRec.EXAC63K_SOUTHASIAN_HEMI_COUNT, valueForKeyAtIndex(infoToks, "Hemi_SAS", altIndex), 1.0);
-			safeParseAndSetProperty(var, VariantRec.EXAC63K_OTHER_HEMI_COUNT, valueForKeyAtIndex(infoToks, "Hemi_OTH", altIndex), 1.0);
+
+			if (justLoadOverall == false){
+				//populations
+				safeParseAndSetProperty(var, VariantRec.EXAC63K_AFRICAN_HEMI_COUNT, valueForKeyAtIndex(infoToks, "Hemi_AFR", altIndex), 1.0);
+				safeParseAndSetProperty(var, VariantRec.EXAC63K_LATINO_HEMI_COUNT, valueForKeyAtIndex(infoToks, "Hemi_AMR", altIndex), 1.0);
+				safeParseAndSetProperty(var, VariantRec.EXAC63K_EASTASIAN_HEMI_COUNT, valueForKeyAtIndex(infoToks, "Hemi_EAS", altIndex), 1.0);
+				safeParseAndSetProperty(var, VariantRec.EXAC63K_EUR_FINNISH_HEMI_COUNT, valueForKeyAtIndex(infoToks, "Hemi_FIN", altIndex), 1.0);
+				safeParseAndSetProperty(var, VariantRec.EXAC63K_EUR_NONFINNISH_HEMI_COUNT, valueForKeyAtIndex(infoToks, "Hemi_NFE", altIndex), 1.0);
+				safeParseAndSetProperty(var, VariantRec.EXAC63K_SOUTHASIAN_HEMI_COUNT, valueForKeyAtIndex(infoToks, "Hemi_SAS", altIndex), 1.0);
+				safeParseAndSetProperty(var, VariantRec.EXAC63K_OTHER_HEMI_COUNT, valueForKeyAtIndex(infoToks, "Hemi_OTH", altIndex), 1.0);
+			}
 		}
-		
+
 		return true;
 	}
 
@@ -211,5 +224,5 @@ public class ExAC63KExomesAnnotator extends AbstractTabixAnnotator {
 		}
 		return null;
 	}
-	
+
 }

--- a/src/main/java/operator/variant/VariantPoolWriter.java
+++ b/src/main/java/operator/variant/VariantPoolWriter.java
@@ -105,7 +105,7 @@ public abstract class VariantPoolWriter extends Operator {
 				List<VariantRec> varList = variants.toList();
 				Collections.sort(varList, recSorter);
 				for(VariantRec var : varList) {
-					System.out.println(var.getContig()+" "+var.getStart()+" "+var.getRef()+" "+var.getAlt());
+					//System.out.println(var.getContig()+" "+var.getStart()+" "+var.getRef()+" "+var.getAlt());
 					writeVariant(var, outStream);
 					tot++;
 				}


### PR DESCRIPTION
The big change was modifying the name of the overall freqs for het hom and hemi to mirror the other ExAC annotations.  For some reason this fixed a larger issue where these overall freqs where not being inserted into the csv or json variant output.  