### PR TITLE
Simplify resolving gene db file in DbNSFP from dbnsfp.gene.path parameter in pipeline_properties.xml

### DIFF
--- a/src/main/java/operator/gene/DBNSFPGeneAnnotator.java
+++ b/src/main/java/operator/gene/DBNSFPGeneAnnotator.java
@@ -27,7 +27,7 @@ public class DBNSFPGeneAnnotator extends AbstractGeneAnnotator {
 	DBNSFPGene db;
 	private File dbFile;
 	public static final String DBNSFPGENE_PATH = "dbnsfp.gene.path";
-	private String dbsnfpVersion = null; 
+	private String dbnsfpVersion = null; 
 	
 	@Override
 	public void annotateGene(Gene g) throws OperationFailedException {
@@ -35,10 +35,10 @@ public class DBNSFPGeneAnnotator extends AbstractGeneAnnotator {
 		if (db == null) {
 			Logger.getLogger(Pipeline.primaryLoggerName).info("dbNSFP-gene looking to use file: " + dbFile.getAbsolutePath());
 			try {
-				if (dbFile.getName().contains("2.0")) dbsnfpVersion = "2.0";
+				if (dbFile.getName().contains("2.0")) dbnsfpVersion = "2.0";
 				//support for 2.0, or 3.1a
-				if (dbsnfpVersion == null) db = DBNSFPGene.getDB(dbFile);
-				else db = new DBNSFPGene( dbFile, dbsnfpVersion);
+				if (dbnsfpVersion == null) db = DBNSFPGene.getDB(dbFile);
+				else db = new DBNSFPGene( dbFile, dbnsfpVersion);
 				
 			} catch (IOException e) {
 				throw new OperationFailedException("Could not initialize dbNSFP gene file " + dbFile.getAbsolutePath() + " : " + e.getMessage(), this);
@@ -64,21 +64,7 @@ public class DBNSFPGeneAnnotator extends AbstractGeneAnnotator {
 		if (pathToDBNSFPGene == null) throw new IllegalArgumentException("No path to dbNSFP specified, cannot use dbNSFP gene annotator");
 		Logger.getLogger(Pipeline.primaryLoggerName).info("dbNSFP-gene reader using directory : " + pathToDBNSFPGene);
 		
-		
-		//look for version, might be null
-		dbsnfpVersion = getAttribute(DBNSFPAnnotator.DBNSFP_VERSION);
-	    if (dbsnfpVersion == null) dbsnfpVersion= getPipelineProperty (DBNSFPAnnotator.DBNSFP_VERSION);
-		
-	    //set file
-	    if (dbsnfpVersion != null && dbsnfpVersion.equals("3.1a")) {
-	    	dbFile = new File(pathToDBNSFPGene + "/dbNSFP3.1_gene");
-	    }
-	    else if (dbsnfpVersion != null && dbsnfpVersion.equals("2.9")){
-	    	dbFile = new File(pathToDBNSFPGene + "/dbNSFP2.9_gene");
-	    }
-	    else {
-	    	dbFile = new File(pathToDBNSFPGene + "/dbNSFP2.0b4_gene");
-	    }
+	    	dbFile = new File(pathToDBNSFPGene);
 	    
 		if (! dbFile.exists()) throw new IllegalArgumentException("DBNSFP file " + dbFile.getAbsolutePath() + " does not exist");
 

--- a/src/main/java/operator/variant/DBNSFPAnnotator.java
+++ b/src/main/java/operator/variant/DBNSFPAnnotator.java
@@ -212,7 +212,7 @@ public class DBNSFPAnnotator extends AbstractTabixAnnotator {
     public static final String DBNSFP_PATH = "dbnsfp.path";
     public static final String DBNSFP_VERSION = "dbnsfp.version";
     public static final Pattern TAB = Pattern.compile("\\t");
-    protected String dbsnfpVersion = null;
+    protected String dbnsfpVersion = null;
     
     private int sift_score_col;
     private int sift_pred_col;
@@ -256,155 +256,155 @@ public class DBNSFPAnnotator extends AbstractTabixAnnotator {
     /**
      * returns the sift column for a specific dbNSFP DB
      *
-     * @param dbsnfpVersion
+     * @param dbnsfpVersion
      * @return column index
      */
-    private int getSiftColumn(String dbsnfpVersion) {
-        if (dbsnfpVersion.equals("3.0") || dbsnfpVersion.equals("3.1a")) return 23;
-        if (dbsnfpVersion.equals("2.9")) return 26; 
-        if (dbsnfpVersion.equals("2.0")) return 21;
+    private int getSiftColumn(String dbnsfpVersion) {
+        if (dbnsfpVersion.equals("3.0") || dbnsfpVersion.equals("3.1a")) return 23;
+        if (dbnsfpVersion.equals("2.9")) return 26; 
+        if (dbnsfpVersion.equals("2.0")) return 21;
         return -1;
     }
     /**
      * returns the sift prediction column for a specific dbNSFP DB
      *
-     * @param dbsnfpVersion
+     * @param dbnsfpVersion
      * @return column index
      */
-    private int getSiftPredColumn(String dbsnfpVersion) {
-        if (dbsnfpVersion.equals("3.0") || dbsnfpVersion.equals("3.1a")) return -1;
-        if (dbsnfpVersion.equals("2.9")) return 28;
-        if (dbsnfpVersion.equals("2.0")) return -1;
+    private int getSiftPredColumn(String dbnsfpVersion) {
+        if (dbnsfpVersion.equals("3.0") || dbnsfpVersion.equals("3.1a")) return -1;
+        if (dbnsfpVersion.equals("2.9")) return 28;
+        if (dbnsfpVersion.equals("2.0")) return -1;
         return -1;
     }
 
     /**
      * returns the Polyphen2_HDIV_score column index for a specific dbNSFP DB
      *
-     * @param dbsnfpVersion
+     * @param dbnsfpVersion
      * @return column index
      */
-    private int getPolyphenScoreColumn(String dbsnfpVersion) {
-        if (dbsnfpVersion.equals("3.0") || dbsnfpVersion.equals("3.1a")) return 29;
-        if (dbsnfpVersion.equals("2.9")) return 29;
-        if (dbsnfpVersion.equals("2.0")) return 22;
+    private int getPolyphenScoreColumn(String dbnsfpVersion) {
+        if (dbnsfpVersion.equals("3.0") || dbnsfpVersion.equals("3.1a")) return 29;
+        if (dbnsfpVersion.equals("2.9")) return 29;
+        if (dbnsfpVersion.equals("2.0")) return 22;
         return -1;
     }
     
     /**
      * Returns the Polyphen2_HVAR_score column index for a specific dbNSFP DB
      *
-     * @param dbsnfpVersion
+     * @param dbnsfpVersion
      * @return column index
      */
-    private int getPolyphenScoreHVARColumn(String dbsnfpVersion) {
-        if (dbsnfpVersion.equals("3.0") || dbsnfpVersion.equals("3.1a")) return 32;
-        if (dbsnfpVersion.equals("2.9")) return 32;
-        if (dbsnfpVersion.equals("2.0")) return 24;
+    private int getPolyphenScoreHVARColumn(String dbnsfpVersion) {
+        if (dbnsfpVersion.equals("3.0") || dbnsfpVersion.equals("3.1a")) return 32;
+        if (dbnsfpVersion.equals("2.9")) return 32;
+        if (dbnsfpVersion.equals("2.0")) return 24;
         return -1;
     }
     /**
      * Returns the Polyphen2_HVAR_PRED column index for a specific dbNSFP DB
      *
-     * @param dbsnfpVersion
+     * @param dbnsfpVersion
      * @return column index
      */
-    private int getPolyphenScoreHVARPREDColumn(String dbsnfpVersion) {
-        if (dbsnfpVersion.equals("3.0") || dbsnfpVersion.equals("3.1a")) return -1;
-        if (dbsnfpVersion.equals("2.9")) return 34;
-        if (dbsnfpVersion.equals("2.0")) return -1;
+    private int getPolyphenScoreHVARPREDColumn(String dbnsfpVersion) {
+        if (dbnsfpVersion.equals("3.0") || dbnsfpVersion.equals("3.1a")) return -1;
+        if (dbnsfpVersion.equals("2.9")) return 34;
+        if (dbnsfpVersion.equals("2.0")) return -1;
         return -1;
     }
 
     /**
      * Returns the LRT_score column index for a specific dbNSFP DB
      *
-     * @param dbsnfpVersion
+     * @param dbnsfpVersion
      * @return column index
      */
-    private int getLRTScoreColumn(String dbsnfpVersion) {
-        if (dbsnfpVersion.equals("3.0") || dbsnfpVersion.equals("3.1a")) return 35;
-        if (dbsnfpVersion.equals("2.9")) return 35;
-        if (dbsnfpVersion.equals("2.0")) return 26;
+    private int getLRTScoreColumn(String dbnsfpVersion) {
+        if (dbnsfpVersion.equals("3.0") || dbnsfpVersion.equals("3.1a")) return 35;
+        if (dbnsfpVersion.equals("2.9")) return 35;
+        if (dbnsfpVersion.equals("2.0")) return 26;
         return -1;
     }
 
     /**
      * Returns the Mutation_taster_score column index for a specific dbNSFP DB
      *
-     * @param dbsnfpVersion
+     * @param dbnsfpVersion
      * @return column index
      */
-    private int getMTScoreColumn(String dbsnfpVersion) {
-        if (dbsnfpVersion.equals("3.0") || dbsnfpVersion.equals("3.1a")) return -1;
-        if (dbsnfpVersion.equals("2.9")) return 38;
-        if (dbsnfpVersion.equals("2.0")) return -1;
+    private int getMTScoreColumn(String dbnsfpVersion) {
+        if (dbnsfpVersion.equals("3.0") || dbnsfpVersion.equals("3.1a")) return -1;
+        if (dbnsfpVersion.equals("2.9")) return 38;
+        if (dbnsfpVersion.equals("2.0")) return -1;
         return -1;
     }
     /**
      * Returns the Mutation_taster_prediction column index for a specific dbNSFP DB
      *
-     * @param dbsnfpVersion
+     * @param dbnsfpVersion
      * @return column index
      */
-    private int getMTPredColumn(String dbsnfpVersion) {
-        if (dbsnfpVersion.equals("3.0") || dbsnfpVersion.equals("3.1a")) return -1;
-        if (dbsnfpVersion.equals("2.9")) return 40;//from 37????
-        if (dbsnfpVersion.equals("2.0")) return -1;
+    private int getMTPredColumn(String dbnsfpVersion) {
+        if (dbnsfpVersion.equals("3.0") || dbnsfpVersion.equals("3.1a")) return -1;
+        if (dbnsfpVersion.equals("2.9")) return 40;//from 37????
+        if (dbnsfpVersion.equals("2.0")) return -1;
         return -1;
     }    
 
     /**
      * Returns the Mutation_Assessor_score column index for a specific dbNSFP DB
      *
-     * @param dbsnfpVersion
+     * @param dbnsfpVersion
      * @return column index
      */
-    private int getMAScoreColumn(String dbsnfpVersion) {
-        if (dbsnfpVersion.equals("3.0") || dbsnfpVersion.equals("3.1a")) return -1;
-        if (dbsnfpVersion.equals("2.9")) return 42;//this is the "converted" score of 0-1
-        if (dbsnfpVersion.equals("2.0")) return -1;
+    private int getMAScoreColumn(String dbnsfpVersion) {
+        if (dbnsfpVersion.equals("3.0") || dbnsfpVersion.equals("3.1a")) return -1;
+        if (dbnsfpVersion.equals("2.9")) return 42;//this is the "converted" score of 0-1
+        if (dbnsfpVersion.equals("2.0")) return -1;
         return -1;
     }   
     
     /**
      * Returns the Mutation_Assessor_prediction column index for a specific dbNSFP DB
      *
-     * @param dbsnfpVersion
+     * @param dbnsfpVersion
      * @return column index
      */
-    private int getMAPredColumn(String dbsnfpVersion) {
-        if (dbsnfpVersion.equals("3.0") || dbsnfpVersion.equals("3.1a")) return -1;
-        if (dbsnfpVersion.equals("2.9")) return 43;
-        if (dbsnfpVersion.equals("2.0")) return -1;
+    private int getMAPredColumn(String dbnsfpVersion) {
+        if (dbnsfpVersion.equals("3.0") || dbnsfpVersion.equals("3.1a")) return -1;
+        if (dbnsfpVersion.equals("2.9")) return 43;
+        if (dbnsfpVersion.equals("2.0")) return -1;
         return -1;
     }    
 
     /**
      * Returns the GERP_NR column index for a specific dbNSFP DB
      *
-     * @param dbsnfpVersion
+     * @param dbnsfpVersion
      * @return column index
      */
-    private int getGerpNRColumn(String dbsnfpVersion) {
-    	if (dbsnfpVersion.equals("3.1a")) return 87;
-    	if (dbsnfpVersion.equals("3.0")) return 62;
-        if (dbsnfpVersion.equals("2.9")) return 62;
-        if (dbsnfpVersion.equals("2.0")) return 32;
+    private int getGerpNRColumn(String dbnsfpVersion) {
+    	if (dbnsfpVersion.equals("3.1a")) return 87;
+    	if (dbnsfpVersion.equals("3.0")) return 62;
+        if (dbnsfpVersion.equals("2.9")) return 62;
+        if (dbnsfpVersion.equals("2.0")) return 32;
         return -1;
     }
 
     /**
      * Returns the GERP_RS column index for a specific dbNSFP DB
      *
-     * @param dbsnfpVersion
+     * @param dbnsfpVersion
      * @return column index
      */
-    private int getGerpColumn(String dbsnfpVersion) {
-    	if (dbsnfpVersion.equals("3.1a")) return 88;
-        if (dbsnfpVersion.equals("3.0")) return 63;
-        if (dbsnfpVersion.equals("2.9")) return 63;
-        if (dbsnfpVersion.equals("2.0")) return 33;
+    private int getGerpColumn(String dbnsfpVersion) {
+    	if (dbnsfpVersion.equals("3.1a")) return 88;
+        if (dbnsfpVersion.equals("3.0")) return 63;
+        if (dbnsfpVersion.equals("2.9")) return 63;
+        if (dbnsfpVersion.equals("2.0")) return 33;
         return -1;
     
     }
@@ -412,14 +412,14 @@ public class DBNSFPAnnotator extends AbstractTabixAnnotator {
     /**
      * Returns the PhyloP column index for a specific dbNSFP DB
      *
-     * @param dbsnfpVersion
+     * @param dbnsfpVersion
      * @return column index
      */
-    private int getPhylopColumn(String dbsnfpVersion) {
-    	if (dbsnfpVersion.equals("3.1a")) return 90;
-        if (dbsnfpVersion.equals("3.0")) return 65;
-        if (dbsnfpVersion.equals("2.9")) return 69;
-        if (dbsnfpVersion.equals("2.0")) return 34;
+    private int getPhylopColumn(String dbnsfpVersion) {
+    	if (dbnsfpVersion.equals("3.1a")) return 90;
+        if (dbnsfpVersion.equals("3.0")) return 65;
+        if (dbnsfpVersion.equals("2.9")) return 69;
+        if (dbnsfpVersion.equals("2.0")) return 34;
         return -1;
 
     }
@@ -427,14 +427,14 @@ public class DBNSFPAnnotator extends AbstractTabixAnnotator {
     /**
      * Returns the SiPhy_29way_logOdds column index for a specific dbNSFP DB
      *
-     * @param dbsnfpVersion
+     * @param dbnsfpVersion
      * @return column index
      */
-    private int getSiphyColumn(String dbsnfpVersion) {
-    	if (dbsnfpVersion.equals("3.1a")) return 99;
-        if (dbsnfpVersion.equals("3.0")) return 70;
-        if (dbsnfpVersion.equals("2.9")) return 78;
-        if (dbsnfpVersion.equals("2.0")) return 36;
+    private int getSiphyColumn(String dbnsfpVersion) {
+    	if (dbnsfpVersion.equals("3.1a")) return 99;
+        if (dbnsfpVersion.equals("3.0")) return 70;
+        if (dbnsfpVersion.equals("2.9")) return 78;
+        if (dbnsfpVersion.equals("2.0")) return 36;
         return -1;
     }
 
@@ -769,33 +769,33 @@ public class DBNSFPAnnotator extends AbstractTabixAnnotator {
     public void initialize(NodeList children) {
         super.initialize(children);
 
-        dbsnfpVersion = getAttribute(DBNSFP_VERSION);
-        if (dbsnfpVersion == null) dbsnfpVersion= getPipelineProperty (DBNSFP_VERSION);
+        dbnsfpVersion = getAttribute(DBNSFP_VERSION);
+        if (dbnsfpVersion == null) dbnsfpVersion= getPipelineProperty (DBNSFP_VERSION);
         
         //I'm going to force a declaration of what version they are using, Nix
-        if (dbsnfpVersion == null) throw new IllegalArgumentException ("Failed to parse your "+DBNSFP_VERSION +". Please include it in your pipeline properties xml file.");
-        else if (dbsnfpVersion.equals("2.0") == false && dbsnfpVersion.equals("2.9") == false && dbsnfpVersion.equals("3.0") == false && dbsnfpVersion.equals("3.1a") == false){
+        if (dbnsfpVersion == null) throw new IllegalArgumentException ("Failed to parse your "+DBNSFP_VERSION +". Please include it in your pipeline properties xml file.");
+        else if (dbnsfpVersion.equals("2.0") == false && dbnsfpVersion.equals("2.9") == false && dbnsfpVersion.equals("3.0") == false && dbnsfpVersion.equals("3.1a") == false){
         	throw new IllegalArgumentException ("Only the 2.0, 2.9, 3.0, 3.1a versions of "+DBNSFP_VERSION +" are supported");
         }
         
         //set column indexes, bad way of doing this!
-        sift_score_col = getSiftColumn(dbsnfpVersion);
-        sift_pred_col = getSiftPredColumn(dbsnfpVersion);
-        polyphen_score_col = getPolyphenScoreColumn(dbsnfpVersion);
-        Polyphen2_hvar_score_col = getPolyphenScoreHVARColumn(dbsnfpVersion);
-        Polyphen2_hvar_pred_col = getPolyphenScoreHVARPREDColumn(dbsnfpVersion);
-        lrt_score_column = getLRTScoreColumn(dbsnfpVersion);
-        mt_score_column = getMTScoreColumn(dbsnfpVersion);
-        mt_pred_column = getMTPredColumn(dbsnfpVersion);
-        ma_pred_column = getMAPredColumn(dbsnfpVersion);
-        ma_score_column = getMAScoreColumn(dbsnfpVersion);
-        gerp_nr_score_column = getGerpNRColumn(dbsnfpVersion);
-        gerp_score_column = getGerpColumn(dbsnfpVersion);
-        phylop_score_column = getPhylopColumn(dbsnfpVersion);
-        siphy_score_column = getSiphyColumn(dbsnfpVersion);
+        sift_score_col = getSiftColumn(dbnsfpVersion);
+        sift_pred_col = getSiftPredColumn(dbnsfpVersion);
+        polyphen_score_col = getPolyphenScoreColumn(dbnsfpVersion);
+        Polyphen2_hvar_score_col = getPolyphenScoreHVARColumn(dbnsfpVersion);
+        Polyphen2_hvar_pred_col = getPolyphenScoreHVARPREDColumn(dbnsfpVersion);
+        lrt_score_column = getLRTScoreColumn(dbnsfpVersion);
+        mt_score_column = getMTScoreColumn(dbnsfpVersion);
+        mt_pred_column = getMTPredColumn(dbnsfpVersion);
+        ma_pred_column = getMAPredColumn(dbnsfpVersion);
+        ma_score_column = getMAScoreColumn(dbnsfpVersion);
+        gerp_nr_score_column = getGerpNRColumn(dbnsfpVersion);
+        gerp_score_column = getGerpColumn(dbnsfpVersion);
+        phylop_score_column = getPhylopColumn(dbnsfpVersion);
+        siphy_score_column = getSiphyColumn(dbnsfpVersion);
         
         //set indexes for the correct columns in a dbnsfp line, first is 0.
-        if (dbsnfpVersion.equals("3.1a")){
+        if (dbnsfpVersion.equals("3.1a")){
             b37Chr_column =7;
             b37Pos_column =8;
             b37Ref_column =2;


### PR DESCRIPTION
@KBoehme , @durtschi

I made the following changes:

Rename the value 'dbsnfpVersion' to 'dbnsfpVersion' so it's more consistent between names.
The DbNSFP gene db file is the value of 'dbnsfp.gene.path' without appending a hard-coded file name based on the version of DbNSFP.