### PR TITLE
Somatic freq fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ snpEffDirLink
 pipeinstance*
 snpeff.input.vcf
 snpeff.output
+.idea/
+*.iml

--- a/src/main/java/json/AnnotatedVarsJsonConverter.java
+++ b/src/main/java/json/AnnotatedVarsJsonConverter.java
@@ -108,12 +108,15 @@ public class AnnotatedVarsJsonConverter {
 		varObj.put("ref", var.getRef());
 		varObj.put("alt", var.getAlt());
 		
-		//Variant frequency defaults to 0, but gets computed from the DEPTH and VAR_DEPTH properties, if available
-		double varFreq = 0.0;
-		if (var.getProperty(VariantRec.DEPTH) != null && var.getProperty(VariantRec.DEPTH) > 0 && var.getProperty(VariantRec.VAR_DEPTH) != null) {
-			varFreq = var.getProperty(VariantRec.VAR_DEPTH) / var.getProperty(VariantRec.DEPTH);
+		//If var.freq already exists (somatic callers) dont bother calculating it.
+		if (!var.hasProperty("var.freq")) {
+			//Variant frequency defaults to 0 (unless already present), but gets computed from the DEPTH and VAR_DEPTH properties, if available
+			double varFreq = 0.0;
+			if (var.getProperty(VariantRec.DEPTH) != null && var.getProperty(VariantRec.DEPTH) > 0 && var.getProperty(VariantRec.VAR_DEPTH) != null) {
+				varFreq = var.getProperty(VariantRec.VAR_DEPTH) / var.getProperty(VariantRec.DEPTH);
+			}
+			varObj.put("var.freq", varFreq);
 		}
-		varObj.put("var.freq", varFreq);
 
 		String zyg = "";
 		if (var.getZygosity() == GTType.HET) {

--- a/src/main/java/util/vcfParser/VCFParser.java
+++ b/src/main/java/util/vcfParser/VCFParser.java
@@ -505,7 +505,13 @@ public class VCFParser implements VariantLineReader {
 		if (varCaller != null){
 			var.addAnnotation(VariantRec.VAR_CALLER, varCaller);
 		}
-	
+
+		// If we have a somatic caller try and grab the AF info field.
+		if (creator.equals("lofreq_scalpel_manta") && sampleMetrics.containsKey("AF")) {
+			double alleleFrequency = convertStr2Double(sampleMetrics.get("AF"));
+			var.addProperty("var.freq", alleleFrequency);
+		}
+
 		Integer altDepth = getVariantDepth();
 		if (altDepth != null) {
 			var.addProperty(VariantRec.VAR_DEPTH, new Double(altDepth));
@@ -862,8 +868,8 @@ public class VCFParser implements VariantLineReader {
 		} else {
 			return new String[0];
 		}
-	}	
-		
+	}
+
 	/**
 	 * Total read depth at locus from INFO column, identified by "DP" and specified for the particular ALT
 	 * @author elainegee


### PR DESCRIPTION
Fix for somatic variant caller allele frequencies. The algo basically goes like this:
1. Checks if the vcf is from somatic callers, if so set the var.freq property on the VariantRec using the AF field in vcf.
2. This value will then propagate to the annotatedJson thingy which will simply check if that value already exists.
3. If it exists it will use it, otherwise it will calculate it using AD and DP (which is what it will do for germline samples).

I ran both a MYE and random recently run cert-prod germline sample. I wrote a script to confirm all var.freq annotations are sourced from the AF field of the vcf, and also ensured that the germline annotated.json.gz files are the exact same (using md5sum).

I also branched from cert and will merge back to cert (hotfix). We discovered too many changes in dev that were undesirable to have in this release.