### PR TITLE
Support for Pindel annos, bump version 1.9.14 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.aruplab.ngs</groupId>
   <artifactId>Pipeline</artifactId>
   <packaging>jar</packaging>
-  <version>1.9.13</version>
+  <version>1.9.14</version>
   <name>Pipeline</name>
   <url>http://maven.apache.org</url>
   <properties>

--- a/src/main/java/buffer/variant/VariantRec.java
+++ b/src/main/java/buffer/variant/VariantRec.java
@@ -1022,5 +1022,9 @@ public class VariantRec {
 
    public static final String MNP_ALLELES = "mnp.alleles";
 
+
+   public static final String PINDEL_ORIG_REF = "pindel.orig.ref";
+   public static final String PINDEL_ORIG_ALT = "pindel.orig.alt";
+
 }
 

--- a/src/main/java/pipeline/Pipeline.java
+++ b/src/main/java/pipeline/Pipeline.java
@@ -48,7 +48,7 @@ import util.text.QueuedLogHandler;
  */
 public class Pipeline {
 
-	public static final String PIPELINE_VERSION = "1.9.13";
+	public static final String PIPELINE_VERSION = "1.9.14";
 	protected File source;
 	protected Document xmlDoc;
 	public static final String PROJECT_HOME="home";

--- a/src/main/java/util/vcfParser/VCFParser.java
+++ b/src/main/java/util/vcfParser/VCFParser.java
@@ -545,6 +545,16 @@ public class VCFParser implements VariantLineReader {
 			}
 		}
 
+		String pindelRef = getPindelRef();
+		if (pindelRef != null) {
+			var.addAnnotation(VariantRec.PINDEL_ORIG_REF, pindelRef);
+		}
+
+		String pindelAlt = getPindelAlt();
+		if (pindelAlt != null) {
+			var.addAnnotation(VariantRec.PINDEL_ORIG_ALT, pindelAlt);
+		}
+
 		String genotypeQuality = getGenotypeQuality();
 		if (genotypeQuality != null) {
 			var.addAnnotation(VariantRec.GENOTYPE_QUALITY, genotypeQuality);
@@ -876,8 +886,8 @@ public class VCFParser implements VariantLineReader {
 		} else {
 			return new String[0];
 		}
-	}
-
+	}	
+		
 	/**
 	 * Total read depth at locus from INFO column, identified by "DP" and specified for the particular ALT
 	 * @author elainegee
@@ -1064,6 +1074,28 @@ public class VCFParser implements VariantLineReader {
 	public String getMNPAlleleComponents() {
 		if (sampleMetrics.containsKey("ALLELES")) {
 			return sampleMetrics.get("ALLELES");
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * Return the bases associated with the 'pindel.orig.ref' field, or null if that key doesn't exist
+	 */
+	public String getPindelRef() {
+		if (sampleMetrics.containsKey("orig_ref")) {
+			return sampleMetrics.get("orig_ref");
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * Return the bases associated with the 'pindel.orig.alt' field, or null if that key doesn't exist
+	 */
+	public String getPindelAlt() {
+		if (sampleMetrics.containsKey("orig_alt")) {
+			return sampleMetrics.get("orig_alt");
 		} else {
 			return null;
 		}

--- a/src/main/java/util/vcfParser/VCFParser.java
+++ b/src/main/java/util/vcfParser/VCFParser.java
@@ -1153,14 +1153,12 @@ public class VCFParser implements VariantLineReader {
 	 * @author jacobd
 	 */
 	public int getInfoEND(){
-		int infoend = -1;
-		if (creator.equals("lofreq_scalpel_manta")){
-			String strinfoend = getSampleMetricsStr("END");
-			if (strinfoend != null) {
-				infoend = convertStr2Int(strinfoend);
-			}
+		String strinfoend = getSampleMetricsStr("END");
+		if (strinfoend != null) {
+			return convertStr2Int(strinfoend);
+		} else {
+			return -1;
 		}
-		return infoend;
 	}
 	
 	/**


### PR DESCRIPTION
Two new annotations required for PINDEL (don't worry, there won't be changes in BioCompModels).
Also one modification to when we parse and store the END field from VCF - previously we only did it when the vcf source==lofreq_scalpel_manta, but now we do it in every case. 