### PR TITLE
Speedup tabix annotators

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.aruplab.ngs</groupId>
   <artifactId>Pipeline</artifactId>
   <packaging>jar</packaging>
-  <version>1.9.14</version>
+  <version>1.9.15</version>
   <name>Pipeline</name>
   <url>http://maven.apache.org</url>
   <properties>

--- a/src/main/java/operator/annovar/Annotator.java
+++ b/src/main/java/operator/annovar/Annotator.java
@@ -164,6 +164,9 @@ public abstract class Annotator extends Operator {
                 List<Future<Integer>> futs = new ArrayList();
                 for (String contig : variants.getContigs()) {
                         List<VariantRec> contigVars = variants.getVariantsForContig(contig);
+
+                        if (contigVars.size() <= 0) { continue; }
+
                         TabixReader reader;
                         try
                         {

--- a/src/main/java/operator/annovar/Annotator.java
+++ b/src/main/java/operator/annovar/Annotator.java
@@ -5,6 +5,17 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.text.DecimalFormat;
 import java.util.logging.Logger;
+import java.util.ArrayList;
+import java.util.List;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import org.broad.tribble.readers.TabixReader;
 
 import json.JSONArray;
 import json.JSONObject;
@@ -35,7 +46,7 @@ public abstract class Annotator extends Operator {
 	protected VariantPool variants = null;
 	protected BEDFile bedFile = null;
 	protected ArupBEDFile arupBedFile = null;
-	
+        public static final String THREAD_KEY = "threads";	
 
 	/**
 	 * Compute or obtain an annotation for the given variant and add it to the list of
@@ -44,7 +55,12 @@ public abstract class Annotator extends Operator {
 	 * @throws OperationFailedException 
 	 */
 	public abstract void annotateVariant(VariantRec var) throws OperationFailedException;
-	
+
+        /**
+         * This MUST be overriden by TabixAnnotators; Make it empty here so Non-TabixAnnotators
+         * do not need to do anything.
+         */
+        public void annotateVariant(VariantRec var, TabixReader Reader) throws OperationFailedException {}	
 	/**
 	 * If true, we write some progress indicators to system.out
 	 * @return
@@ -57,14 +73,141 @@ public abstract class Annotator extends Operator {
 	public VariantPool getVariants() {
 		return variants;
 	}
+
+        /**
+         * This shold be overriden by AbstractTabixAnnotator and return true
+         */ 
+        protected boolean isTabixAnnotator() {
+                return false;
+        }
+
+        /**
+         * This should be overriden by AbstractTabixAnnotator and never be used by
+         * NonTabixAnnotators
+         */
+        protected String getPathToTabixedFile() { 
+               return "Error: called on NonTabixAnnotators!";  
+        }
 	
 	public void performOperation() throws OperationFailedException {
 		if (variants == null)
 			throw new OperationFailedException("No variant pool specified", this);
-		
+
+                if (isTabixAnnotator() == true) {
+                        tabixOperation();
+                } else {
+                    nonTabixOperation();
+                }
+        }
+
+
+        /**
+         * This inner class implements Callable and its call function will be used to 
+         * annotate variants in the list of VariantRec objects; This should only be 
+         * used by TabixAnnotators.
+         **/
+        public class TabixCallable implements Callable<Integer> {
+            int myVarsAnnotated = 0;
+            List<VariantRec> varList;
+            TabixReader reader;
+  
+            public TabixCallable(List<VariantRec> vList, TabixReader trr) {
+                this.varList = vList;
+                this.reader = trr;
+            }
+  
+            public Integer call() throws Exception {
+                for (VariantRec rec : varList) {
+                    Integer recLength = Integer.valueOf(rec.getRef().length() - rec.getAlt().length());
+                    if (recLength.intValue() < 0) {
+                        recLength = Integer.valueOf(0);
+                    } else if (recLength.intValue() == 0) {
+                        if (rec.getRef().length() == 1) {
+                            recLength = Integer.valueOf(1);
+                        } else {
+                                recLength = Integer.valueOf(rec.getRef().length());
+                        }
+                    }
+                    Integer recEnd = Integer.valueOf(rec.getStart() - 1 + recLength.intValue());
+                    Interval recInterval = new Interval(rec.getStart() - 1, recEnd.intValue());
+                    if ((bedFile == null) || (bedFile.intersects(rec.getContig(), recInterval))) {
+                        annotateVariant(rec, reader);
+                    }
+                    myVarsAnnotated += 1;
+                }
+
+                return new Integer(myVarsAnnotated);
+
+            }
+        }
+
+        /** 
+         * For TabixAnnotators only, sprawn multiple threads to speed up!
+         */
+        protected void tabixOperation() throws OperationFailedException {
+                prepare();
+
+                int varsAnnotated = 0;
+
+                String str_threads = this.getPipelineProperty(THREAD_KEY);
+                int n_threads = 1;
+                try {
+                    n_threads = Integer.parseInt(str_threads);
+                } catch (NumberFormatException e) {
+                    n_threads = 1;
+                }
+                if (n_threads > 24) { n_threads = 24; }
+                if (n_threads < 1) { n_threads = 1; } 
+
+                ExecutorService execPool = Executors.newFixedThreadPool(n_threads);
+                    
+                List<Future<Integer>> futs = new ArrayList();
+                for (String contig : variants.getContigs()) {
+                        List<VariantRec> contigVars = variants.getVariantsForContig(contig);
+                        TabixReader reader;
+                        try
+                        {
+                               reader = new TabixReader(getPathToTabixedFile());
+                        } catch (IOException e) {
+                                throw new IllegalArgumentException("Error opening " + getPathToTabixedFile() + " errror : " + e.getMessage()); 
+                        }
+                        TabixCallable callable = new TabixCallable(contigVars, reader);
+                      
+                        Future<Integer> fut = execPool.submit(callable);
+                        futs.add(fut);
+                }
+                    
+                for (Future<Integer> fut : futs) {
+                        try {
+                                varsAnnotated += ((Integer)fut.get()).intValue();
+                        } catch (InterruptedException ierr) {
+                                System.out.println("Interrupted exception:");
+                                ierr.printStackTrace();
+                        } catch (ExecutionException err) {
+                                System.out.println("Exeuction exception:");
+                                err.printStackTrace();
+                                throw new OperationFailedException(err.toString(), this);
+                        }
+                }
+                    
+                execPool.shutdown();
+                try {
+                        if (!execPool.awaitTermination(1L, TimeUnit.SECONDS)) {
+                                execPool.shutdownNow();
+                        }
+                } catch (InterruptedException ie) {
+                        execPool.shutdownNow();
+                }
+                    
+                cleanup();
+        }                
+        
+        /**
+         * For Non-TabixAnnotators, the same as the sequential version.
+         */
+        protected void nonTabixOperation() throws OperationFailedException {
 		DecimalFormat formatter = new DecimalFormat("#0.00");
 		int tot = variants.size();
-		
 	
 		prepare();
 		

--- a/src/main/java/operator/variant/AbstractTabixAnnotator.java
+++ b/src/main/java/operator/variant/AbstractTabixAnnotator.java
@@ -2,12 +2,22 @@ package operator.variant;
 
 import java.io.IOException;
 import java.util.logging.Logger;
+import java.util.ArrayList;
+import java.util.List;                  
+                                        
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
 import operator.OperationFailedException;
 import operator.annovar.Annotator;
 
 import org.broad.tribble.readers.TabixReader;
 
+import util.Interval;
 import pipeline.Pipeline;
 import util.vcfParser.VCFParser;
 import buffer.variant.VariantRec;
@@ -23,15 +33,10 @@ import buffer.variant.VariantRec;
  *
  */
 public abstract class AbstractTabixAnnotator extends Annotator {
+        public static final String THREAD_KEY = "threads";	
 
-        @Override
-        protected boolean isTabixAnnotator() {
-            return true;
-        }
 
-        @Override    
         protected abstract String getPathToTabixedFile();
-
 
 	/**
 	 * Subclasses should override this method to actually perform the annotations.
@@ -49,11 +54,6 @@ public abstract class AbstractTabixAnnotator extends Annotator {
 
 	protected abstract boolean addAnnotationsFromString(VariantRec variantToAnnotate, String vcfLine, int altIndex) throws OperationFailedException;
 
-    
-
-	protected void initializeReader(String filePath) {
-
-	}
 
 	/**
 	 * This overrides the 'prepare' method in the base Annotator class. It is always called 
@@ -111,20 +111,17 @@ public abstract class AbstractTabixAnnotator extends Annotator {
 		return -1;
 	}
 
-        
         /**
-         * This method won't be used by any subclasses so make it empty.
+         * This method won't be used by TabixedAnnotators at all.
          */
-        @Override 
-        public void annotateVariant(VariantRec varToAnnotate) throws OperationFailedException {
-        }
-	
+        public final void annotateVariant(VariantRec var) throws OperationFailedException {}
+ 
+        
 	/**
 	 * This actually annotates the variant - it performs new tabix query, then converts the
 	 * result to a normalized VariantRec, then sees if the normalized VariantRec matches the
-	 * variant we want to annotate. If so 
+	 * variant we want to annotate. 
 	 */
-	@Override
 	public void annotateVariant(VariantRec varToAnnotate, TabixReader reader) throws OperationFailedException {
 
 		String contig = varToAnnotate.getContig();
@@ -168,6 +165,107 @@ public abstract class AbstractTabixAnnotator extends Annotator {
 			}
 		}
 	}
-	
+
+        /**
+         * This inner class implements Callable and its call function will be used to 
+         * annotate variants in the list of VariantRec objects; This should only be 
+         * used by TabixAnnotators.
+         **/
+        public class TabixCallable implements Callable<Integer> {
+            int myVarsAnnotated = 0;
+            List<VariantRec> varList;
+            TabixReader reader;
+  
+            public TabixCallable(List<VariantRec> vList, TabixReader trr) {
+                this.varList = vList;
+                this.reader = trr;
+            }
+  
+            public Integer call() throws Exception {
+                for (VariantRec rec : varList) {
+                    Integer recLength = Integer.valueOf(rec.getRef().length() - rec.getAlt().length());
+                    if (recLength.intValue() < 0) {
+                        recLength = Integer.valueOf(0);
+                    } else if (recLength.intValue() == 0) {
+                        if (rec.getRef().length() == 1) {
+                            recLength = Integer.valueOf(1);
+                        } else {
+                                recLength = Integer.valueOf(rec.getRef().length());
+                        }
+                    }
+                    Integer recEnd = Integer.valueOf(rec.getStart() - 1 + recLength.intValue());
+                    Interval recInterval = new Interval(rec.getStart() - 1, recEnd.intValue());
+                    if ((bedFile == null) || (bedFile.intersects(rec.getContig(), recInterval))) {
+                        annotateVariant(rec, reader);
+                    }
+                    myVarsAnnotated += 1;
+                }
+
+                return new Integer(myVarsAnnotated);
+
+            }
+        }
+
+        @Override	
+        public void performOperation() throws OperationFailedException {
+                prepare();
+
+                int varsAnnotated = 0;
+
+                String str_threads = this.getPipelineProperty(THREAD_KEY);
+                int n_threads = 1;
+                try {
+                    n_threads = Integer.parseInt(str_threads);
+                } catch (NumberFormatException e) {
+                    n_threads = 1;
+                }
+                if (n_threads > 24) { n_threads = 24; }
+                if (n_threads < 1) { n_threads = 1; } 
+
+                ExecutorService execPool = Executors.newFixedThreadPool(n_threads);
+                    
+                List<Future<Integer>> futs = new ArrayList();
+                for (String contig : variants.getContigs()) {
+                        List<VariantRec> contigVars = variants.getVariantsForContig(contig);
+
+                        if (contigVars.size() <= 0) { continue; }
+
+                        TabixReader reader;
+                        try
+                        {
+                               reader = new TabixReader(getPathToTabixedFile());
+                        } catch (IOException e) {
+                                throw new IllegalArgumentException("Error opening " + getPathToTabixedFile() + " errror : " + e.getMessage()); 
+                        }
+                        TabixCallable callable = new TabixCallable(contigVars, reader);
+                      
+                        Future<Integer> fut = execPool.submit(callable);
+                        futs.add(fut);
+                }
+                    
+                for (Future<Integer> fut : futs) {
+                        try {
+                                varsAnnotated += ((Integer)fut.get()).intValue();
+                        } catch (InterruptedException ierr) {
+                                System.out.println("Interrupted exception:");
+                                ierr.printStackTrace();
+                                throw new OperationFailedException(ierr.toString(), this);
+                        } catch (ExecutionException err) {
+                                System.out.println("Exeuction exception:");
+                                err.printStackTrace();
+                                throw new OperationFailedException(err.toString(), this);
+                        }
+                }
+                    
+                execPool.shutdown();
+                try {
+                        if (!execPool.awaitTermination(1L, TimeUnit.SECONDS)) {
+                                execPool.shutdownNow();
+                        }
+                } catch (InterruptedException ie) {
+                        execPool.shutdownNow();
+                }
+                    
+        }
 
 }

--- a/src/main/java/operator/variant/AbstractTabixAnnotator.java
+++ b/src/main/java/operator/variant/AbstractTabixAnnotator.java
@@ -24,14 +24,13 @@ import buffer.variant.VariantRec;
  */
 public abstract class AbstractTabixAnnotator extends Annotator {
 
-	private boolean initialized = false;
-	private TabixReader reader = null;
+        @Override
+        protected boolean isTabixAnnotator() {
+            return true;
+        }
 
-	/**
-	 * Should return the path to the file we want to read
-	 * @return
-	 */
-	protected abstract String getPathToTabixedFile();
+        @Override    
+        protected abstract String getPathToTabixedFile();
 
 
 	/**
@@ -50,14 +49,10 @@ public abstract class AbstractTabixAnnotator extends Annotator {
 
 	protected abstract boolean addAnnotationsFromString(VariantRec variantToAnnotate, String vcfLine, int altIndex) throws OperationFailedException;
 
+    
+
 	protected void initializeReader(String filePath) {
 
-		try {
-			reader = new TabixReader(filePath);
-		} catch (IOException e) {
-			throw new IllegalArgumentException("Error opening data at path " + filePath + " error : " + e.getMessage());
-		}
-		initialized = true;
 	}
 
 	/**
@@ -65,8 +60,8 @@ public abstract class AbstractTabixAnnotator extends Annotator {
 	 * prior to the first call to annotateVariant, and gives us a chance to do a little
 	 * initialization. 
 	 */
+        @Override
 	protected void prepare() throws OperationFailedException {
-		initializeReader( getPathToTabixedFile());
 	}
 
 
@@ -115,6 +110,14 @@ public abstract class AbstractTabixAnnotator extends Annotator {
 		}//Loop over alts	
 		return -1;
 	}
+
+        
+        /**
+         * This method won't be used by any subclasses so make it empty.
+         */
+        @Override 
+        public void annotateVariant(VariantRec varToAnnotate) throws OperationFailedException {
+        }
 	
 	/**
 	 * This actually annotates the variant - it performs new tabix query, then converts the
@@ -122,15 +125,7 @@ public abstract class AbstractTabixAnnotator extends Annotator {
 	 * variant we want to annotate. If so 
 	 */
 	@Override
-	public void annotateVariant(VariantRec varToAnnotate) throws OperationFailedException {
-
-		if (! initialized) {
-			throw new OperationFailedException("Failed to initialize", this);
-		}
-
-		if (reader == null) {
-			throw new OperationFailedException("Tabix reader not initialized", this);
-		}
+	public void annotateVariant(VariantRec varToAnnotate, TabixReader reader) throws OperationFailedException {
 
 		String contig = varToAnnotate.getContig();
 		Integer pos = varToAnnotate.getStart();

--- a/src/main/java/operator/variant/DBNSFPAnnotator.java
+++ b/src/main/java/operator/variant/DBNSFPAnnotator.java
@@ -206,9 +206,6 @@ cat dbNSFP3.1a_variant.chr1.sorted dbNSFP3.1a_variant.chr2.sorted dbNSFP3.1a_var
 
 public class DBNSFPAnnotator extends AbstractTabixAnnotator {
 
-    private boolean initialized = false;
-    private TabixReader reader = null;
-
     public static final String DBNSFP_PATH = "dbnsfp.path";
     public static final String DBNSFP_VERSION = "dbnsfp.version";
     public static final Pattern TAB = Pattern.compile("\\t");
@@ -241,15 +238,6 @@ public class DBNSFPAnnotator extends AbstractTabixAnnotator {
     @Override
     protected String getPathToTabixedFile() {
         return searchForAttribute(DBNSFP_PATH);
-    }
-
-    protected void initializeReader(String filePath) {
-        try {
-            reader = new TabixReader(filePath);
-        } catch (IOException e) {
-            throw new IllegalArgumentException("Error opening data at path " + filePath + " error : " + e.getMessage());
-        }
-        initialized = true;
     }
 
 
@@ -716,10 +704,7 @@ public class DBNSFPAnnotator extends AbstractTabixAnnotator {
      * @throws OperationFailedException
      */
     @Override
-    public void annotateVariant(VariantRec varToAnnotate) throws OperationFailedException {
-
-        if (!initialized) throw new OperationFailedException("Failed to initialize", this);
-        if (reader == null) throw new OperationFailedException("Tabix reader not initialized", this);
+    public void annotateVariant(VariantRec varToAnnotate, TabixReader reader) throws OperationFailedException {
 
         String contig = varToAnnotate.getContig();
         Integer pos = varToAnnotate.getStart();

--- a/src/main/java/operator/variant/ESP6500Annotator.java
+++ b/src/main/java/operator/variant/ESP6500Annotator.java
@@ -14,8 +14,6 @@ import buffer.variant.VariantRec;
 public class ESP6500Annotator extends AbstractTabixAnnotator {
 
 	public static final String ESP_PATH = "esp.path";
-	private boolean hasHaploidObservations = false;
-	private boolean isYChromVariant        = false;
 
 	@Override
 	protected String getPathToTabixedFile() {
@@ -34,17 +32,19 @@ public class ESP6500Annotator extends AbstractTabixAnnotator {
 	
 	protected boolean addAnnotationsFromString(VariantRec var, String dbline, int altIndex) {
 	        String[] GTSStringArray = null;
+	        boolean isYChromVariant  = false;
+		boolean hasHaploidObservations = false;
+
 		String[] toks = dbline.split("\t");
 		String[] infoToks = toks[7].split(";");
 		Double totOverall = 0.0;
 		Double homOverall = 0.0;
-		isYChromVariant = false;
-		hasHaploidObservations = false;
 		int homRefIndex = -1;
 		int hetIndex = -1;
 		int homAltIndex = -1;
 		int haploidRefIndex = -1;		
 		int haploidAltIndex = -1;
+
 		//Start by getting the indexes of our allele combinations of interest. We will use these indexes to pull the freqs from EA_GTC etc.
 		for(int i=0; i<infoToks.length; i++) {
 			String tok = infoToks[i];

--- a/src/main/java/operator/variant/ESP6500Annotator.java
+++ b/src/main/java/operator/variant/ESP6500Annotator.java
@@ -16,16 +16,15 @@ public class ESP6500Annotator extends AbstractTabixAnnotator {
 	public static final String ESP_PATH = "esp.path";
 	private boolean hasHaploidObservations = false;
 	private boolean isYChromVariant        = false;
-	String[] GTSStringArray = null;
 
 	@Override
 	protected String getPathToTabixedFile() {
 		return searchForAttribute(ESP_PATH);
 	}
 
-	private boolean hasHaploidCalls() {
-		for(int j = 0; j < GTSStringArray.length; j++) {
-			if (GTSStringArray[j].length() == 1) {
+	private boolean hasHaploidCalls(String[] GTS) {
+		for(int j = 0; j < GTS.length; j++) {
+			if (GTS[j].length() == 1) {
 				return true;
 			}
 		}
@@ -34,6 +33,7 @@ public class ESP6500Annotator extends AbstractTabixAnnotator {
 	
 	
 	protected boolean addAnnotationsFromString(VariantRec var, String dbline, int altIndex) {
+	        String[] GTSStringArray = null;
 		String[] toks = dbline.split("\t");
 		String[] infoToks = toks[7].split(";");
 		Double totOverall = 0.0;
@@ -63,7 +63,7 @@ public class ESP6500Annotator extends AbstractTabixAnnotator {
 				if (var.getContig().equals("Y")) { //Y Chrom.
 					isYChromVariant = true;
 				}
-				hasHaploidObservations = hasHaploidCalls();
+				hasHaploidObservations = hasHaploidCalls(GTSStringArray);
 				
 				if (tok.contains("R")) { //Indel
 					String altString = "A" + String.valueOf(altIndex+1); //Base 1 ie A1 in DB, but altindex is 0 based.

--- a/src/main/java/operator/variant/MitoMapFrequency.java
+++ b/src/main/java/operator/variant/MitoMapFrequency.java
@@ -34,7 +34,7 @@ public class MitoMapFrequency extends AbstractTabixAnnotator {
 	 */
 	@Override
 	protected void prepare() throws OperationFailedException {
-		initializeReader( getPathToTabixedFile());
+		//initializeReader( getPathToTabixedFile());
 		//get total alleles from freq vcf header
 		this.totalAlleles = getTotalAlleles();
 	}

--- a/src/test/java/annotation/TestDBNSFP.java
+++ b/src/test/java/annotation/TestDBNSFP.java
@@ -7,6 +7,8 @@ import operator.variant.DBNSFPAnnotator;
 
 import org.junit.Assert;
 
+import org.broad.tribble.readers.TabixReader;
+
 import pipeline.Pipeline;
 import util.vcfParser.VCFParser;
 import buffer.variant.VariantRec;
@@ -27,6 +29,11 @@ public class TestDBNSFP extends TestCase {
     DBNSFPAnnotator annotator_30;//currently commented out
     DBNSFPAnnotator annotator_29;
     DBNSFPAnnotator annotator_292;
+
+    TabixReader reader_30;
+    TabixReader reader_29;
+    TabixReader reader_292;
+
     boolean thrown;
 
     public void setUp() {
@@ -38,7 +45,8 @@ public class TestDBNSFP extends TestCase {
             ppl.initializePipeline();
             ppl.stopAllLogging();
             ppl.execute();
-           annotator_30 = (DBNSFPAnnotator) ppl.getObjectHandler().getObjectForLabel("GeneAnnotate30");
+            annotator_30 = (DBNSFPAnnotator) ppl.getObjectHandler().getObjectForLabel("GeneAnnotate30");
+            reader_30 = new TabixReader((String)ppl.getProperty("dbnsfp.path"));
 
 
             Pipeline ppl2 = new Pipeline(inputFile, propertiesFile.getAbsolutePath());
@@ -49,7 +57,7 @@ public class TestDBNSFP extends TestCase {
             ppl2.stopAllLogging();
             ppl2.execute();
             annotator_29 = (DBNSFPAnnotator) ppl2.getObjectHandler().getObjectForLabel("GeneAnnotate29");
-            
+            reader_29 = new TabixReader((String)ppl2.getProperty("dbnsfp.path")); 
             
             Pipeline ppl3 = new Pipeline(inputFile, propertiesFile.getAbsolutePath());
             ppl3.setProperty(
@@ -59,7 +67,7 @@ public class TestDBNSFP extends TestCase {
             ppl3.stopAllLogging();
             ppl3.execute();
             annotator_292 = (DBNSFPAnnotator) ppl3.getObjectHandler().getObjectForLabel("GeneAnnotate292");
-            
+            reader_292 = new TabixReader((String)ppl3.getProperty("dbnsfp.path")); 
 
 
         } catch (Exception ex) {
@@ -73,12 +81,12 @@ public class TestDBNSFP extends TestCase {
         try {
             VariantRec var1 = new VariantRec("1", 35138,  35138, "T", "A");
             var1 = VCFParser.normalizeVariant(var1);
-            annotator_292.annotateVariant(var1);
+            annotator_292.annotateVariant(var1, reader_292);
             Assert.assertNull(var1.getAnnotation(VariantRec.SIFT_SCORE));
 
             VariantRec varNull = new VariantRec("1", 883869, 883869, "C", "T");
             varNull = VCFParser.normalizeVariant(varNull);
-            annotator_292.annotateVariant(varNull);
+            annotator_292.annotateVariant(varNull, reader_292);
             Assert.assertNull(varNull.getAnnotation(VariantRec.SIFT_SCORE));
             Assert.assertNull(var1.getProperty(VariantRec.POLYPHEN_SCORE));
             Assert.assertNull(var1.getProperty(VariantRec.POLYPHEN_HVAR_SCORE));
@@ -101,11 +109,11 @@ public class TestDBNSFP extends TestCase {
         try {
             VariantRec var1 = new VariantRec("X", 78216484, 78216484, "T", "A");
             var1 = VCFParser.normalizeVariant(var1);
-            annotator_292.annotateVariant(var1);
+            annotator_292.annotateVariant(var1, reader_292);
 
             VariantRec varNull = new VariantRec("X", 78216484, 78216484, "T", "C");//double check this
             varNull = VCFParser.normalizeVariant(varNull);
-            annotator_292.annotateVariant(varNull);
+            annotator_292.annotateVariant(varNull, reader_292);
 
             Assert.assertEquals(0.011, var1.getProperty(VariantRec.SIFT_SCORE), 0);
             Assert.assertEquals(0.908, var1.getProperty(VariantRec.POLYPHEN_HVAR_SCORE), 0);
@@ -129,12 +137,12 @@ public class TestDBNSFP extends TestCase {
         try {
             VariantRec var1 = new VariantRec("19", 48946461, 48946461, "C", "T");
             var1 = VCFParser.normalizeVariant(var1);
-            annotator_292.annotateVariant(var1);
+            annotator_292.annotateVariant(var1, reader_292);
             Assert.assertEquals(0.001, var1.getProperty(VariantRec.SIFT_SCORE), 0);
 
             VariantRec varNull = new VariantRec("19", 48946461, 48946461, "T", "C");
             varNull = VCFParser.normalizeVariant(varNull);
-            annotator_292.annotateVariant(varNull);
+            annotator_292.annotateVariant(varNull, reader_292);
 
             Assert.assertEquals(0.045, var1.getProperty(VariantRec.POLYPHEN_HVAR_SCORE), 0);
             Assert.assertEquals(0.139850, var1.getProperty(VariantRec.LRT_SCORE), 0);
@@ -157,17 +165,17 @@ public class TestDBNSFP extends TestCase {
         try {
             VariantRec var1 = new VariantRec("19", 15636185, 15636185, "G", "C");
             var1 = VCFParser.normalizeVariant(var1);
-            annotator_292.annotateVariant(var1);
+            annotator_292.annotateVariant(var1, reader_292);
             Assert.assertEquals(0.023, var1.getProperty(VariantRec.SIFT_SCORE), 0);
 
             VariantRec var2 = new VariantRec("12", 25249910, 25249910, "A", "G");
             var2 = VCFParser.normalizeVariant(var2);
-            annotator_292.annotateVariant(var2);
+            annotator_292.annotateVariant(var2, reader_292);
             Assert.assertEquals(0.106, var2.getProperty(VariantRec.SIFT_SCORE), 0);
 
             VariantRec varNull = new VariantRec("19", 15636185, 15636185, "T", "A");
             varNull = VCFParser.normalizeVariant(varNull);
-            annotator_292.annotateVariant(varNull);
+            annotator_292.annotateVariant(varNull, reader_292);
             Assert.assertNull(varNull.getProperty(VariantRec.SIFT_SCORE));
 
 
@@ -186,12 +194,12 @@ public class TestDBNSFP extends TestCase {
         try {
             VariantRec var1 = new VariantRec("12", 25699414, 25699414, "A", "G");
             var1 = VCFParser.normalizeVariant(var1);
-            annotator_292.annotateVariant(var1);
+            annotator_292.annotateVariant(var1, reader_292);
             Assert.assertEquals(0.998, var1.getProperty(VariantRec.POLYPHEN_HVAR_SCORE), 0);
 
             VariantRec varNull = new VariantRec("12", 25699414, 25699414, "T", "A");
             varNull = VCFParser.normalizeVariant(varNull);
-            annotator_292.annotateVariant(varNull);
+            annotator_292.annotateVariant(varNull, reader_292);
             Assert.assertNull(varNull.getProperty(VariantRec.POLYPHEN_HVAR_SCORE));
         } catch (Exception ex) {
             thrown = true;
@@ -206,12 +214,12 @@ public class TestDBNSFP extends TestCase {
         try {
             VariantRec var1 = new VariantRec("10", 22830948, 22830948, "T", "C");
             var1 = VCFParser.normalizeVariant(var1);
-            annotator_292.annotateVariant(var1);
+            annotator_292.annotateVariant(var1, reader_292);
             Assert.assertEquals(0.000001, var1.getProperty(VariantRec.LRT_SCORE), 0);
 
             VariantRec varNull = new VariantRec("10", 22607060, 22607060, "T", "A");
             varNull = VCFParser.normalizeVariant(varNull);
-            annotator_292.annotateVariant(varNull);
+            annotator_292.annotateVariant(varNull, reader_292);
             Assert.assertNull(varNull.getProperty(VariantRec.LRT_SCORE));
         } catch (Exception ex) {
             thrown = true;
@@ -226,12 +234,12 @@ public class TestDBNSFP extends TestCase {
         try {
             VariantRec var1 = new VariantRec("1", 1139566, 1139566, "T", "G");
             var1 = VCFParser.normalizeVariant(var1);
-            annotator_292.annotateVariant(var1);
+            annotator_292.annotateVariant(var1, reader_292);
             Assert.assertEquals(0.999998, var1.getProperty(VariantRec.MT_SCORE), 0);
 
             VariantRec varNull = new VariantRec("1", 1139566, 1139566, "T", "A");
             varNull = VCFParser.normalizeVariant(varNull);
-            annotator_292.annotateVariant(varNull);
+            annotator_292.annotateVariant(varNull, reader_292);
             Assert.assertNull(varNull.getProperty(VariantRec.MT_SCORE));
         } catch (Exception ex) {
             thrown = true;
@@ -246,12 +254,12 @@ public class TestDBNSFP extends TestCase {
         try {
             VariantRec var1 = new VariantRec("11", 71146654, 71146654, "A", "T");
             var1 = VCFParser.normalizeVariant(var1);
-            annotator_292.annotateVariant(var1);
+            annotator_292.annotateVariant(var1, reader_292);
             Assert.assertEquals(0.87347, var1.getProperty(VariantRec.MA_SCORE), 0);
 
             VariantRec varNull = new VariantRec("11", 71146654, 71146654, "A", "G");
             varNull = VCFParser.normalizeVariant(varNull);
-            annotator_292.annotateVariant(varNull);
+            annotator_292.annotateVariant(varNull, reader_292);
             Assert.assertNull(varNull.getProperty(VariantRec.MA_SCORE));
         } catch (Exception ex) {
             thrown = true;
@@ -266,12 +274,12 @@ public class TestDBNSFP extends TestCase {
         try {
             VariantRec var1 = new VariantRec("6", 90402250, 90402250, "A", "T");
             var1 = VCFParser.normalizeVariant(var1);
-            annotator_292.annotateVariant(var1);
+            annotator_292.annotateVariant(var1, reader_292);
             Assert.assertEquals(5.67, var1.getProperty(VariantRec.GERP_NR_SCORE), 0);
 
             VariantRec varNull = new VariantRec("6", 90402250, 90402250, "T", "A");
             varNull = VCFParser.normalizeVariant(varNull);
-            annotator_292.annotateVariant(varNull);
+            annotator_292.annotateVariant(varNull, reader_292);
             Assert.assertNull(varNull.getProperty(VariantRec.GERP_NR_SCORE));
         } catch (Exception ex) {
             thrown = true;
@@ -287,12 +295,12 @@ public class TestDBNSFP extends TestCase {
         try {
             VariantRec var1 = new VariantRec("5", 72800195, 72800195, "G", "C");
             var1 = VCFParser.normalizeVariant(var1);
-            annotator_292.annotateVariant(var1);
+            annotator_292.annotateVariant(var1, reader_292);
             Assert.assertEquals(5.61, var1.getProperty(VariantRec.GERP_SCORE), 0);
 
             VariantRec varNull = new VariantRec("5", 72800195, 72800195, "T", "A");
             varNull = VCFParser.normalizeVariant(varNull);
-            annotator_292.annotateVariant(varNull);
+            annotator_292.annotateVariant(varNull, reader_292);
             Assert.assertNull(varNull.getProperty(VariantRec.GERP_SCORE));
         } catch (Exception ex) {
             thrown = true;
@@ -307,12 +315,12 @@ public class TestDBNSFP extends TestCase {
             //8959:12.8949
             VariantRec var1 = new VariantRec("4", 140309231, 140309231, "A", "G");
             var1 = VCFParser.normalizeVariant(var1);
-            annotator_292.annotateVariant(var1);
+            annotator_292.annotateVariant(var1, reader_292);
             Assert.assertEquals(16.3636, var1.getProperty(VariantRec.SIPHY_SCORE), 0);
 
             VariantRec varNull = new VariantRec("X", 154262983, 154262983, "T", "A");
             varNull = VCFParser.normalizeVariant(varNull);
-            annotator_292.annotateVariant(varNull);
+            annotator_292.annotateVariant(varNull, reader_292);
             Assert.assertNull(varNull.getProperty(VariantRec.SIPHY_SCORE));
         } catch (Exception ex) {
             thrown = true;
@@ -327,7 +335,7 @@ public class TestDBNSFP extends TestCase {
         try {
             VariantRec var1 = new VariantRec("1", 35138,  35138, "T", "A");
             var1 = VCFParser.normalizeVariant(var1);
-            annotator_29.annotateVariant(var1);
+            annotator_29.annotateVariant(var1, reader_29);
             //System.out.println(var1.toString());
             //Assert.assertEquals(0.0, var1.getProperty(VariantRec.SIFT_SCORE), 0);
             Assert.assertNull(var1.getAnnotation(VariantRec.SIFT_SCORE));
@@ -336,7 +344,7 @@ public class TestDBNSFP extends TestCase {
 
             VariantRec varNull = new VariantRec("1", 883869, 883869, "C", "T");
             varNull = VCFParser.normalizeVariant(varNull);
-            annotator_29.annotateVariant(varNull);
+            annotator_29.annotateVariant(varNull, reader_29);
             //System.out.println(varNull.getAnnotation(VariantRec.SIFT_SCORE));
             Assert.assertNull(varNull.getAnnotation(VariantRec.SIFT_SCORE));
 
@@ -386,13 +394,13 @@ public class TestDBNSFP extends TestCase {
         try {
             VariantRec var1 = new VariantRec("Y", 28133957, 28133957, "G", "T");
             var1 = VCFParser.normalizeVariant(var1);
-            annotator_29.annotateVariant(var1);
+            annotator_29.annotateVariant(var1, reader_29);
             Assert.assertNull(var1.getProperty(VariantRec.SIFT_SCORE));
             //Assert.assertTrue(var1.getProperty(VariantRec.SIPHY_SCORE).equals("0.13"));
 
             VariantRec varNull = new VariantRec("Y", 28133957, 28133957, "T", "C");
             varNull = VCFParser.normalizeVariant(varNull);
-            annotator_29.annotateVariant(varNull);
+            annotator_29.annotateVariant(varNull, reader_29);
 
             //System.out.println(varNull.getAnnotation(VariantRec.SIFT_SCORE));
             Assert.assertNull(varNull.getAnnotation(VariantRec.SIFT_SCORE));
@@ -429,13 +437,13 @@ public class TestDBNSFP extends TestCase {
         try {
             VariantRec var1 = new VariantRec("19", 48946461, 48946461, "C", "T");
             var1 = VCFParser.normalizeVariant(var1);
-            annotator_29.annotateVariant(var1);
+            annotator_29.annotateVariant(var1, reader_29);
             Assert.assertEquals(0.001, var1.getProperty(VariantRec.SIFT_SCORE), 0);
             //Assert.assertTrue(var1.getProperty(VariantRec.SIPHY_SCORE).equals("0.13"));
 
             VariantRec varNull = new VariantRec("19", 48946461, 48946461, "T", "C");
             varNull = VCFParser.normalizeVariant(varNull);
-            annotator_29.annotateVariant(varNull);
+            annotator_29.annotateVariant(varNull, reader_29);
 //            //System.out.println(varNull.getAnnotation(VariantRec.SIFT_SCORE));
 
 //          var.addProperty(VariantRec.POLYPHEN_SCORE, Double.parseDouble(toks[29]));
@@ -473,19 +481,19 @@ public class TestDBNSFP extends TestCase {
         try {
             VariantRec var1 = new VariantRec("19", 15636185, 15636185, "G", "C");
             var1 = VCFParser.normalizeVariant(var1);
-            annotator_29.annotateVariant(var1);
+            annotator_29.annotateVariant(var1, reader_29);
             Assert.assertEquals(0.023, var1.getProperty(VariantRec.SIFT_SCORE), 0);
 
             VariantRec var2 = new VariantRec("12", 25249910, 25249910, "A", "G");
             var2 = VCFParser.normalizeVariant(var2);
-            annotator_29.annotateVariant(var2);
+            annotator_29.annotateVariant(var2, reader_29);
             Assert.assertEquals(0.106, var2.getProperty(VariantRec.SIFT_SCORE), 0);
 
 
 
             VariantRec varNull = new VariantRec("19", 15636185, 15636185, "T", "A");
             varNull = VCFParser.normalizeVariant(varNull);
-            annotator_29.annotateVariant(varNull);
+            annotator_29.annotateVariant(varNull, reader_29);
             Assert.assertNull(varNull.getProperty(VariantRec.SIFT_SCORE));
 
 
@@ -505,12 +513,12 @@ public class TestDBNSFP extends TestCase {
         try {
             VariantRec var1 = new VariantRec("16", 685297, 685297, "A", "G");
             var1 = VCFParser.normalizeVariant(var1);
-            annotator_29.annotateVariant(var1);
+            annotator_29.annotateVariant(var1, reader_29);
             Assert.assertEquals(0.622, var1.getProperty(VariantRec.POLYPHEN_SCORE), 0);
 
             VariantRec varNull = new VariantRec("16", 685297, 685297, "T", "A");
             varNull = VCFParser.normalizeVariant(varNull);
-            annotator_29.annotateVariant(varNull);
+            annotator_29.annotateVariant(varNull, reader_29);
             Assert.assertNull(varNull.getProperty(VariantRec.POLYPHEN_SCORE));
         } catch (Exception ex) {
             thrown = true;
@@ -527,12 +535,12 @@ public class TestDBNSFP extends TestCase {
         try {
             VariantRec var1 = new VariantRec("12", 25699414, 25699414, "A", "G");
             var1 = VCFParser.normalizeVariant(var1);
-            annotator_29.annotateVariant(var1);
+            annotator_29.annotateVariant(var1, reader_29);
             Assert.assertEquals(0.998, var1.getProperty(VariantRec.POLYPHEN_HVAR_SCORE), 0);
 
             VariantRec varNull = new VariantRec("12", 25699414, 25699414, "T", "A");
             varNull = VCFParser.normalizeVariant(varNull);
-            annotator_29.annotateVariant(varNull);
+            annotator_29.annotateVariant(varNull, reader_29);
             Assert.assertNull(varNull.getProperty(VariantRec.POLYPHEN_HVAR_SCORE));
         } catch (Exception ex) {
             thrown = true;
@@ -547,12 +555,12 @@ public class TestDBNSFP extends TestCase {
         try {
             VariantRec var1 = new VariantRec("10", 22830948, 22830948, "T", "C");
             var1 = VCFParser.normalizeVariant(var1);
-            annotator_29.annotateVariant(var1);
+            annotator_29.annotateVariant(var1, reader_29);
             Assert.assertEquals(0.000001, var1.getProperty(VariantRec.LRT_SCORE), 0);
 
             VariantRec varNull = new VariantRec("10", 22607060, 22607060, "T", "A");
             varNull = VCFParser.normalizeVariant(varNull);
-            annotator_29.annotateVariant(varNull);
+            annotator_29.annotateVariant(varNull, reader_29);
             Assert.assertNull(varNull.getProperty(VariantRec.LRT_SCORE));
         } catch (Exception ex) {
             thrown = true;
@@ -567,12 +575,12 @@ public class TestDBNSFP extends TestCase {
         try {
             VariantRec var1 = new VariantRec("X", 78216484, 78216484, "T", "G");
             var1 = VCFParser.normalizeVariant(var1);
-            annotator_29.annotateVariant(var1);
+            annotator_29.annotateVariant(var1, reader_29);
             Assert.assertEquals(0.768, var1.getProperty(VariantRec.MT_SCORE), 0);
 
             VariantRec varNull = new VariantRec("X", 78216484, 78216484, "T", "A");
             varNull = VCFParser.normalizeVariant(varNull);
-            annotator_29.annotateVariant(varNull);
+            annotator_29.annotateVariant(varNull, reader_29);
             Assert.assertNull(varNull.getProperty(VariantRec.MT_SCORE));
         } catch (Exception ex) {
             thrown = true;
@@ -586,11 +594,11 @@ public class TestDBNSFP extends TestCase {
         try {
             VariantRec var1 = new VariantRec("X", 78216484, 78216484, "T", "G");
             var1 = VCFParser.normalizeVariant(var1);
-            annotator_29.annotateVariant(var1);
+            annotator_29.annotateVariant(var1, reader_29);
             Assert.assertTrue(var1.getAnnotation(VariantRec.MT_PRED).equals("polymorphism"));
             VariantRec varNull = new VariantRec("X", 78216484, 78216484, "T", "A");
             varNull = VCFParser.normalizeVariant(varNull);
-            annotator_29.annotateVariant(varNull);
+            annotator_29.annotateVariant(varNull, reader_29);
             Assert.assertNull(varNull.getProperty(VariantRec.MT_PRED));
         } catch (Exception ex) {
             thrown = true;
@@ -605,12 +613,12 @@ public class TestDBNSFP extends TestCase {
         try {
             VariantRec var1 = new VariantRec("11", 71146654, 71146654, "A", "T");
             var1 = VCFParser.normalizeVariant(var1);
-            annotator_29.annotateVariant(var1);
+            annotator_29.annotateVariant(var1, reader_29);
             Assert.assertEquals(0.79805, var1.getProperty(VariantRec.MA_SCORE), 0);
 
             VariantRec varNull = new VariantRec("11", 71146654, 71146654, "A", "C");
             varNull = VCFParser.normalizeVariant(varNull);
-            annotator_29.annotateVariant(varNull);
+            annotator_29.annotateVariant(varNull, reader_29);
             Assert.assertNull(varNull.getProperty(VariantRec.MA_SCORE));
         } catch (Exception ex) {
             thrown = true;
@@ -624,12 +632,12 @@ public class TestDBNSFP extends TestCase {
         try {
             VariantRec var1 = new VariantRec("11", 71146654, 71146654, "A", "T");
             var1 = VCFParser.normalizeVariant(var1);
-            annotator_29.annotateVariant(var1);
+            annotator_29.annotateVariant(var1, reader_29);
             Assert.assertTrue(var1.getAnnotation(VariantRec.MA_PRED).equals("M"));
 
             VariantRec varNull = new VariantRec("11", 71146654, 71146654, "A", "C");
             varNull = VCFParser.normalizeVariant(varNull);
-            annotator_29.annotateVariant(varNull);
+            annotator_29.annotateVariant(varNull, reader_29);
             Assert.assertNull(varNull.getProperty(VariantRec.MA_PRED));
         } catch (Exception ex) {
             thrown = true;
@@ -643,12 +651,12 @@ public class TestDBNSFP extends TestCase {
         try {
             VariantRec var1 = new VariantRec("6", 90402250, 90402250, "A", "T");
             var1 = VCFParser.normalizeVariant(var1);
-            annotator_29.annotateVariant(var1);
+            annotator_29.annotateVariant(var1, reader_29);
             Assert.assertEquals(5.64, var1.getProperty(VariantRec.GERP_NR_SCORE), 0);
 
             VariantRec varNull = new VariantRec("6", 90402250, 90402250, "T", "A");
             varNull = VCFParser.normalizeVariant(varNull);
-            annotator_29.annotateVariant(varNull);
+            annotator_29.annotateVariant(varNull, reader_29);
             Assert.assertNull(varNull.getProperty(VariantRec.GERP_NR_SCORE));
         } catch (Exception ex) {
             thrown = true;
@@ -664,12 +672,12 @@ public class TestDBNSFP extends TestCase {
         try {
             VariantRec var1 = new VariantRec("5", 72800195, 72800195, "G", "C");
             var1 = VCFParser.normalizeVariant(var1);
-            annotator_29.annotateVariant(var1);
+            annotator_29.annotateVariant(var1, reader_29);
             Assert.assertEquals(5.61, var1.getProperty(VariantRec.GERP_SCORE), 0);
 
             VariantRec varNull = new VariantRec("5", 72800195, 72800195, "T", "A");
             varNull = VCFParser.normalizeVariant(varNull);
-            annotator_29.annotateVariant(varNull);
+            annotator_29.annotateVariant(varNull, reader_29);
             Assert.assertNull(varNull.getProperty(VariantRec.GERP_SCORE));
         } catch (Exception ex) {
             thrown = true;
@@ -684,12 +692,12 @@ public class TestDBNSFP extends TestCase {
             //5985:-0.448000
             VariantRec var1 = new VariantRec("4", 140394089, 140394089, "G", "T");
             var1 = VCFParser.normalizeVariant(var1);
-            annotator_29.annotateVariant(var1);
+            annotator_29.annotateVariant(var1, reader_29);
             Assert.assertEquals(8.062, var1.getProperty(VariantRec.PHYLOP_SCORE), 0);
 
             VariantRec varNull = new VariantRec("4", 140394089, 140394089, "T", "A");
             varNull = VCFParser.normalizeVariant(varNull);
-            annotator_29.annotateVariant(varNull);
+            annotator_29.annotateVariant(varNull, reader_29);
             Assert.assertNull(varNull.getProperty(VariantRec.PHYLOP_SCORE));
         } catch (Exception ex) {
             thrown = true;
@@ -705,12 +713,12 @@ public class TestDBNSFP extends TestCase {
             //8959:12.8949
             VariantRec var1 = new VariantRec("4", 140309231, 140309231, "A", "G");
             var1 = VCFParser.normalizeVariant(var1);
-            annotator_29.annotateVariant(var1);
+            annotator_29.annotateVariant(var1, reader_29);
             Assert.assertEquals(16.3636, var1.getProperty(VariantRec.SIPHY_SCORE), 0);
 
             VariantRec varNull = new VariantRec("X", 154262983, 154262983, "T", "A");
             varNull = VCFParser.normalizeVariant(varNull);
-            annotator_29.annotateVariant(varNull);
+            annotator_29.annotateVariant(varNull, reader_29);
             Assert.assertNull(varNull.getProperty(VariantRec.SIPHY_SCORE));
         } catch (Exception ex) {
             thrown = true;

--- a/src/test/java/annotation/TestESP6500.java
+++ b/src/test/java/annotation/TestESP6500.java
@@ -6,6 +6,8 @@ import junit.framework.TestCase;
 import operator.OperationFailedException;
 import operator.variant.ESP6500Annotator;
 
+import org.broad.tribble.readers.TabixReader;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -17,6 +19,7 @@ public class TestESP6500 extends TestCase {
 	File inputFile = new File("src/test/java/annotation/testESP6500.xml");
 	File propertiesFile = new File("src/test/java/core/inputFiles/testProperties.xml"); //do I need?
 	ESP6500Annotator annotator;
+        TabixReader reader;
 	boolean thrown;
 
 	public void setUp() {
@@ -27,6 +30,7 @@ public class TestESP6500 extends TestCase {
 			ppl.stopAllLogging();
 			ppl.execute();
 			annotator = (ESP6500Annotator) ppl.getObjectHandler().getObjectForLabel("ESPAnnotator");
+                        reader = new TabixReader((String)ppl.getProperty("esp.path"));
 
 		} catch (Exception ex) {
 			thrown = true;
@@ -59,7 +63,7 @@ public class TestESP6500 extends TestCase {
 			VariantRec var1 = new VariantRec("15", 43678542, 43678542, "CGTATATATAT", "CAT");
 
 			var1 = VCFParser.normalizeVariant(var1);
-			annotator.annotateVariant(var1);
+			annotator.annotateVariant(var1, reader);
 
 			Assert.assertEquals(.306513, var1.getProperty(VariantRec.EXOMES_FREQ_EA), 0.0001);
 			Assert.assertEquals(.2528, var1.getProperty(VariantRec.EXOMES_FREQ_AA), 0.0001);
@@ -77,7 +81,7 @@ public class TestESP6500 extends TestCase {
 			VariantRec var2 = new VariantRec("15", 43678542, 43678542, "CGTATATATAT", "CATATAT"); //CATAT CATATAT
 
 			var2 = VCFParser.normalizeVariant(var2);
-			annotator.annotateVariant(var2);
+			annotator.annotateVariant(var2, reader);
 
 			Assert.assertEquals(.306513, var2.getProperty(VariantRec.EXOMES_FREQ_EA), 0.0001);
 			Assert.assertEquals(.2528, var2.getProperty(VariantRec.EXOMES_FREQ_AA), 0.0001);
@@ -96,7 +100,7 @@ public class TestESP6500 extends TestCase {
 			VariantRec var3 = new VariantRec("15", 43678542, 43678542, "CGTATATATAT", "CATATATAT");
 
 			var3 = VCFParser.normalizeVariant(var3);
-			annotator.annotateVariant(var3);
+			annotator.annotateVariant(var3, reader);
 
 			Assert.assertEquals(.306513, var3.getProperty(VariantRec.EXOMES_FREQ_EA), 0.0001);
 			Assert.assertEquals(.2528, var3.getProperty(VariantRec.EXOMES_FREQ_AA), 0.0001);
@@ -133,7 +137,7 @@ public class TestESP6500 extends TestCase {
 			VariantRec var1 = new VariantRec("X", 154158158, 154158158, "T", "C");
 
 			var1 = VCFParser.normalizeVariant(var1);
-			annotator.annotateVariant(var1);
+			annotator.annotateVariant(var1, reader);
 
 			Assert.assertEquals(0.0149/100, var1.getProperty(VariantRec.EXOMES_FREQ_EA), 0.0000001);
 			Assert.assertEquals(0.0, var1.getProperty(VariantRec.EXOMES_FREQ_AA), 0.0000001);
@@ -169,7 +173,7 @@ public class TestESP6500 extends TestCase {
 
 		var1 = VCFParser.normalizeVariant(var1);
 		try {
-			annotator.annotateVariant(var1);
+			annotator.annotateVariant(var1, reader);
 		} catch (OperationFailedException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();

--- a/src/test/java/annotation/TestExAC63KExomesAnnotator.java
+++ b/src/test/java/annotation/TestExAC63KExomesAnnotator.java
@@ -5,6 +5,8 @@ import java.io.File;
 import org.junit.Assert;
 import org.junit.Test;
 
+import org.broad.tribble.readers.TabixReader;
+
 import buffer.variant.VariantPool;
 import buffer.variant.VariantRec;
 import junit.framework.TestCase;
@@ -23,7 +25,7 @@ public class TestExAC63KExomesAnnotator extends TestCase {
 	Pipeline pplVCF;
 	
 	ExAC63KExomesAnnotator annotatorVCF;
-	ExAC63KExomesAnnotator annotatorCSV;
+        TabixReader vcf_reader;
 	
 	boolean thrown;
 	
@@ -47,6 +49,7 @@ public class TestExAC63KExomesAnnotator extends TestCase {
 			pplVCF.stopAllLogging();
 			pplVCF.execute();
 			annotatorVCF = (ExAC63KExomesAnnotator) pplVCF.getObjectHandler().getObjectForLabel("ExACAnnotator");
+                        vcf_reader = new TabixReader((String)pplVCF.getProperty("63k.db.path"));
 			
 			
 		} catch (Exception ex) {
@@ -72,7 +75,7 @@ public class TestExAC63KExomesAnnotator extends TestCase {
 			//1       17407   .       G       A       137942.94       PASS    AC=438;AC_AFR=30;AC_AMR=15;AC_Adj=398;AC_EAS=27;AC_FIN=3;AC_Het=398;AC_Hom=0;AC_NFE=266;AC_OTH=4;AC_SAS=53;AF=0.034;AN=13052;AN_AFR=990;AN_AMR=278;AN_Adj=5202;AN_EAS=402;AN_FIN=110;AN_NFE=2974;AN_OTH=56;AN_SAS=392;BaseQRankSum=2.38;ClippingRankSum=0.209;DP=197149;FS=0.000;GQ_MEAN=41.41;GQ_STDDEV=77.70;Het_AFR=30;Het_AMR=15;Het_EAS=27;Het_FIN=3;Het_NFE=266;Het_OTH=4;Het_SAS=53;Hom_AFR=0;Hom_AMR=0;Hom_EAS=0;Hom_FIN=0;Hom_NFE=0;Hom_OTH=0;Hom_SAS=0
 			VariantRec var = new VariantRec("1", 17407, 17407, "G", "A");
 			var = VCFParser.normalizeVariant(var);
-			annotatorVCF.annotateVariant(var);
+			annotatorVCF.annotateVariant(var, vcf_reader);
 			
 			//overall
 			Assert.assertTrue(var.getProperty(VariantRec.EXAC63K_OVERALL_ALLELE_COUNT).equals(Double.valueOf(398)));
@@ -137,7 +140,7 @@ public class TestExAC63KExomesAnnotator extends TestCase {
 			//AN=120606;AN_AFR=8544;AN_AMR=11082;AN_Adj=115186;AN_EAS=8044;AN_FIN=6360;AN_NFE=65406;AN_OTH=872;AN_SAS=14878;BaseQRankSum=0.257;ClippingRankSum=-4.420e-01;DB;DP=2479243;FS=60.859;GQ_MEAN=75.48;GQ_STDDEV=36.33;Het_AFR=517,37,15;Het_AMR=122,31,1;Het_EAS=181,8,3;Het_FIN=38,0,0;Het_NFE=331,29,3;Het_OTH=6,0,0;Het_SAS=311,79,31;Hom_AFR=361,0;Hom_AMR=17,1;Hom_EAS=94,0;Hom_FIN=8,0;Hom_NFE=54,0;Hom_OTH=3,0;Hom_SAS=209,6
 			VariantRec var2A1 = new VariantRec("1", 1636400, 1636400, "G", "A");
 			var2A1 = VCFParser.normalizeVariant(var2A1);
-			annotatorVCF.annotateVariant(var2A1);
+			annotatorVCF.annotateVariant(var2A1, vcf_reader);
 			
 			//overall
 			Assert.assertTrue(var2A1.getProperty(VariantRec.EXAC63K_OVERALL_ALLELE_COUNT).equals(Double.valueOf(3051)));
@@ -191,7 +194,7 @@ public class TestExAC63KExomesAnnotator extends TestCase {
 			//------------------ var2.A2 -----------------------------------------
 			VariantRec var2A2 = new VariantRec("1", 1636400, 1636400, "G", "C");
 			var2A2 = VCFParser.normalizeVariant(var2A2);
-			annotatorVCF.annotateVariant(var2A2);
+			annotatorVCF.annotateVariant(var2A2, vcf_reader);
 
 			//overall  	251 	115186 	7 	0.002179 
 			Assert.assertTrue(var2A2.getProperty(VariantRec.EXAC63K_OVERALL_ALLELE_COUNT).equals(Double.valueOf(251)));
@@ -255,7 +258,7 @@ public class TestExAC63KExomesAnnotator extends TestCase {
 			//X       100276147       rs56176072      C       T       10110649.85     PASS    AC=5744;AC_AFR=78;AC_AMR=144;AC_Adj=4174;AC_EAS=0;AC_FIN=440;AC_Hemi=1520;AC_Het=2466;AC_Hom=94;AC_NFE=3380;AC_OTH=26;AC_SAS=106;AF=0.047;AN=121410;AN_AFR=8509;AN_AMR=9307;AN_Adj=87627;AN_EAS=6623;AN_FIN=4521;AN_NFE=47933;AN_OTH=632;AN_SAS=10102;BaseQRankSum=-7.130e-01;ClippingRankSum=-2.840e-01;DB;DP=1949974;FS=0.518;GQ_MEAN=125.43;GQ_STDDEV=301.48;Hemi_AFR=13;Hemi_AMR=33;Hemi_EAS=0;Hemi_FIN=188;Hemi_NFE=1207;Hemi_OTH=7;Hemi_SAS=72;Het_AFR=65;Het_AMR=105;Het_EAS=0;Het_FIN=230;Het_NFE=2015;Het_OTH=19;Het_SAS=32;Hom_AFR=0;Hom_AMR=3;Hom_EAS=0;Hom_FIN=11;Hom_NFE=79;Hom_OTH=0;Hom_SAS=1;
 			VariantRec var = new VariantRec("X", 100276147, 100276147, "C", "T");
 			var = VCFParser.normalizeVariant(var);
-			annotatorVCF.annotateVariant(var);
+			annotatorVCF.annotateVariant(var, vcf_reader);
 			
 			//overall  	 	4174 	87627 	94 	1520 	0.04763
 			Assert.assertTrue(var.getProperty(VariantRec.EXAC63K_OVERALL_ALLELE_COUNT).equals(Double.valueOf(4174)));
@@ -330,7 +333,7 @@ public class TestExAC63KExomesAnnotator extends TestCase {
 			//X       100083015       rs141539257     C       T,A     163996.46       PASS    AC=138,7;AC_AFR=114,0;AC_AMR=3,0;AC_Adj=117,5;AC_EAS=0,0;AC_FIN=0,0;AC_Hemi=15,2;AC_Het=98,3,0;AC_Hom=2,0;AC_NFE=0,5;AC_OTH=0,0;AC_SAS=0,0;AF=1.137e-03,5.766e-05;AN=121404;AN_AFR=8328;AN_AMR=9028;AN_Adj=83644;AN_EAS=6523;AN_FIN=4328;AN_NFE=46005;AN_OTH=595;AN_SAS=8837;BaseQRankSum=-1.580e-01;ClippingRankSum=-1.560e-01;DB;DP=1593387;FS=1.982;GQ_MEAN=63.15;GQ_STDDEV=48.54;Hemi_AFR=14,0;Hemi_AMR=1,0;Hemi_EAS=0,0;Hemi_FIN=0,0;Hemi_NFE=0,2;Hemi_OTH=0,0;Hemi_SAS=0,0;Het_AFR=96,0,0;Het_AMR=2,0,0;Het_EAS=0,0,0;Het_FIN=0,0,0;Het_NFE=0,3,0;Het_OTH=0,0,0;Het_SAS=0,0,0;Hom_AFR=2,0;Hom_AMR=0,0;Hom_EAS=0,0;Hom_FIN=0,0;Hom_NFE=0,0;Hom_OTH=0,0;Hom_SAS=0,0;InbreedingCoeff=0.2339;
 			VariantRec varA1 = new VariantRec("X", 100083015, 100276147, "C", "T");
 			varA1 = VCFParser.normalizeVariant(varA1);
-			annotatorVCF.annotateVariant(varA1);
+			annotatorVCF.annotateVariant(varA1, vcf_reader);
 			
 			//overall  	 	117 	83644 	2 	15 	0.001399 
 			Assert.assertTrue(varA1.getProperty(VariantRec.EXAC63K_OVERALL_ALLELE_COUNT).equals(Double.valueOf(117)));
@@ -394,7 +397,7 @@ public class TestExAC63KExomesAnnotator extends TestCase {
 			//---------- varA2 ---------------------------------------------------
 			VariantRec varA2 = new VariantRec("X", 100083015, 100276147, "C", "A");
 			varA2 = VCFParser.normalizeVariant(varA2);
-			annotatorVCF.annotateVariant(varA2);
+			annotatorVCF.annotateVariant(varA2, vcf_reader);
 			
 			//overall  	 	5 	83644 	0 	2 	0.00005978 
 			Assert.assertTrue(varA2.getProperty(VariantRec.EXAC63K_OVERALL_ALLELE_COUNT).equals(Double.valueOf(5)));

--- a/src/test/java/annotation/TestScSNV.java
+++ b/src/test/java/annotation/TestScSNV.java
@@ -5,6 +5,8 @@ import java.io.File;
 import junit.framework.TestCase;
 import operator.variant.ScSNVAnnotate;
 
+import org.broad.tribble.readers.TabixReader;
+
 import org.junit.Assert;
 
 import pipeline.Pipeline;
@@ -30,6 +32,7 @@ public class TestScSNV extends TestCase {
 	
 	File inputFile = new File("src/test/java/annotation/testScSNV.xml");
 	File propertiesFile = new File("src/test/java/core/inputFiles/testProperties.xml");
+        TabixReader reader;
 	
 	public void testTestScSnc() {
 		
@@ -43,12 +46,13 @@ public class TestScSNV extends TestCase {
 			
 			//Check to see if UK10KAnnotator is adding the correct AF value annotations
 			ScSNVAnnotate annotator = (ScSNVAnnotate)ppl.getObjectHandler().getObjectForLabel("GeneAnnotate");
+                        reader = new TabixReader((String)ppl.getProperty("dbScSNV.path"));
 		
 			//1       860327  A       C       n       y       upstream        SAMD11  .       .       UTR5    ENSG00000187634 .       .       0.00430955476585136     0.04
 			//Create variants to test variants within the DBscSNC file
 			//scores null
 			VariantRec var = new VariantRec("1", 860327, 860327, "A", "C"); 
-			annotator.annotateVariant(var);
+			annotator.annotateVariant(var, reader);
 			Assert.assertNull(var.getProperty(VariantRec.scSNV_ada)); 
 			Assert.assertNull(var.getProperty(VariantRec.scSNV_rf)); 
 			
@@ -56,7 +60,7 @@ public class TestScSNV extends TestCase {
 			
 			//chr 1 scores 0.998702789872202       0.922
 			VariantRec var1 = new VariantRec("1", 7846900, 7846900, "A", "T"); 
-			annotator.annotateVariant(var1);
+			annotator.annotateVariant(var1, reader);
 			Assert.assertTrue(var1.getProperty(VariantRec.scSNV_ada).equals(0.998702789872202)); 
 			Assert.assertTrue(var1.getProperty(VariantRec.scSNV_rf).equals(.922)); 
 			
@@ -65,14 +69,14 @@ public class TestScSNV extends TestCase {
 			
 			//chr 2 scores  0.996337829495143       0.428
 			VariantRec var2 = new VariantRec("2", 96542261, 96542261, "C", "G"); 
-			annotator.annotateVariant(var2);
+			annotator.annotateVariant(var2, reader);
 			Assert.assertTrue(var2.getProperty(VariantRec.scSNV_ada).equals(0.996337829495143)); 
 			Assert.assertTrue(var2.getProperty(VariantRec.scSNV_rf).equals(0.428)); 
 			
 			//chr 2 scores 0.0186767150217838      .
 			//rf score should be null
 			VariantRec var3 = new VariantRec("2", 153520487, 153520487, "G", "A"); 
-			annotator.annotateVariant(var3);
+			annotator.annotateVariant(var3, reader);
 			Assert.assertTrue(var3.getProperty(VariantRec.scSNV_ada).equals(0.0186767150217838)); 
 			Assert.assertNull(var3.getProperty(VariantRec.scSNV_rf)); 
 			
@@ -80,7 +84,7 @@ public class TestScSNV extends TestCase {
 			//chr 4 scores 4.53814986019981E-5     .
 		    //rf score should be null
 			VariantRec var4 = new VariantRec("4", 71065869, 71065869, "A", "G"); 
-			annotator.annotateVariant(var4);
+			annotator.annotateVariant(var4, reader);
 			Assert.assertTrue(var4.getProperty(VariantRec.scSNV_ada).equals(Double.parseDouble("4.53814986019981E-5"))); 
 			Assert.assertNull(var4.getProperty(VariantRec.scSNV_rf)); 
 			
@@ -88,28 +92,28 @@ public class TestScSNV extends TestCase {
 			
 			//chr 6 scores 1.39980422642338E-4     0.0
 			VariantRec var5 = new VariantRec("6", 150111201, 150111201, "G", "T"); 
-			annotator.annotateVariant(var5);
+			annotator.annotateVariant(var5, reader);
 			Assert.assertTrue(var5.getProperty(VariantRec.scSNV_ada).equals(Double.parseDouble("1.39980422642338E-4"))); 
 			Assert.assertTrue(var5.getProperty(VariantRec.scSNV_rf).equals(0.0)); 
 			
 			//modified from above
 			//chr X scores 0.878218844657696       0.608
 			VariantRec var6 = new VariantRec("X", 101572115, 101572115, "T", "G"); 
-			annotator.annotateVariant(var6);
+			annotator.annotateVariant(var6, reader);
 			Assert.assertTrue(var6.getProperty(VariantRec.scSNV_ada).equals(0.878218844657696)); 
 			Assert.assertTrue(var6.getProperty(VariantRec.scSNV_rf).equals(0.608)); 
 			
 			//Test first line
 			// scores  2.93008933363103E-5     0.0
 			VariantRec var7 = new VariantRec("1",  1139623,  1139623, "T", "A");
-			annotator.annotateVariant(var7);
+			annotator.annotateVariant(var7, reader);
 			Assert.assertTrue(var7.getProperty(VariantRec.scSNV_ada).equals(2.93008933363103E-5)); 
 			Assert.assertTrue(var7.getProperty(VariantRec.scSNV_rf).equals(0.0)); 
 			
 			//test first line alternative SNV
 			//null
 			VariantRec var8 = new VariantRec("1",  1139623,  1139623, "T", "C"); 
-			annotator.annotateVariant(var8);
+			annotator.annotateVariant(var8, reader);
 			Assert.assertNull(var8.getProperty(VariantRec.scSNV_ada));
 			Assert.assertNull(var8.getProperty(VariantRec.scSNV_rf));
 			
@@ -117,28 +121,28 @@ public class TestScSNV extends TestCase {
 			//test before first line
 			//null
 			VariantRec var9 = new VariantRec("1",  1139622,  1139622, "T", "C"); 
-			annotator.annotateVariant(var9);
+			annotator.annotateVariant(var9, reader);
 			Assert.assertNull(var9.getProperty(VariantRec.scSNV_ada));
 			Assert.assertNull(var9.getProperty(VariantRec.scSNV_rf));
 			
 			//Test last line
 			//scores 0.999806680513166       0.94
 			VariantRec var10 = new VariantRec("X", 154213081, 154213081, "G", "C"); 
-			annotator.annotateVariant(var10);
+			annotator.annotateVariant(var10, reader);
 			Assert.assertTrue(var10.getProperty(VariantRec.scSNV_ada).equals(0.999806680513166));
 			Assert.assertTrue(var10.getProperty(VariantRec.scSNV_rf).equals(0.94));
 			
 			//Test last line with variant not present
 			//NULL NULL
 			VariantRec var11 = new VariantRec("X", 154213081, 154213081, "G", "A"); 
-			annotator.annotateVariant(var11);
+			annotator.annotateVariant(var11, reader);
 			Assert.assertNull(var11.getProperty(VariantRec.scSNV_ada));
 			Assert.assertNull(var11.getProperty(VariantRec.scSNV_rf));
 			
 			//Test beyond last line not present
 			//NULL NULL
 			VariantRec var12 = new VariantRec("X", 154213082, 154213082, "G", "A"); 
-			annotator.annotateVariant(var12);
+			annotator.annotateVariant(var12, reader);
 			Assert.assertNull(var12.getProperty(VariantRec.scSNV_ada));
 			Assert.assertNull(var12.getProperty(VariantRec.scSNV_rf));
 			
@@ -150,9 +154,9 @@ public class TestScSNV extends TestCase {
 			VariantRec var13 = new VariantRec("1", 24785368, 24785368, "T", "A"); 
 			VariantRec var14 = new VariantRec("1", 24785368, 24785368, "T", "C"); 
 			VariantRec var15 = new VariantRec("1", 24785368, 24785368, "T", "G"); 
-			annotator.annotateVariant(var13);
-			annotator.annotateVariant(var14);
-			annotator.annotateVariant(var15);
+			annotator.annotateVariant(var13, reader);
+			annotator.annotateVariant(var14, reader);
+			annotator.annotateVariant(var15, reader);
 			
 			Assert.assertTrue(var13.getProperty(VariantRec.scSNV_ada).equals(0.999978160008217));
 			Assert.assertTrue(var13.getProperty(VariantRec.scSNV_rf).equals(0.97));
@@ -165,7 +169,7 @@ public class TestScSNV extends TestCase {
 			
 			//null
 			VariantRec var16 = new VariantRec("1", 24785368, 24785368, "T", "T"); 
-			annotator.annotateVariant(var16);
+			annotator.annotateVariant(var16, reader);
 			Assert.assertNull(var16.getProperty(VariantRec.scSNV_ada));
 			Assert.assertNull(var16.getProperty(VariantRec.scSNV_rf));
 			


### PR DESCRIPTION
In this PR,  Annotators that inherit from AbstractTabixAnnotator class can use multiple CPU cores to improve their speed. Using Pipeline.jar generated by this PR should make annotate_reivew_directory rule in Pipey to run about 4 times faster on machines with 8 CPU cores for EXOME/GUBER samples. 