### PR TITLE
Bus 374 fix snpeff symbolic alts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.aruplab.ngs</groupId>
   <artifactId>Pipeline</artifactId>
   <packaging>jar</packaging>
-  <version>1.9.15</version>
+  <version>1.9.17</version>
   <name>Pipeline</name>
   <url>http://maven.apache.org</url>
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.aruplab.ngs</groupId>
   <artifactId>Pipeline</artifactId>
   <packaging>jar</packaging>
-  <version>1.9.17</version>
+  <version>1.9.16</version>
   <name>Pipeline</name>
   <url>http://maven.apache.org</url>
   <properties>

--- a/src/main/java/operator/snpeff/SnpEffGeneAnnotate.java
+++ b/src/main/java/operator/snpeff/SnpEffGeneAnnotate.java
@@ -153,12 +153,13 @@ public class SnpEffGeneAnnotate extends Annotator {
 	/**
 	 * InfoToks should be field 7 from a VCF record (the INFO column), we split this into tokens on ; and search for the END field,
 	 * If found return it, otherwise return '.'
+	 * In general, this must match the output format of convertVariantFromINFOEnd
 	 * @return Either the END entry from the INFO field, or "." if no END found
 	 */
 	private String findInfoEndFromVCF(String infotoks) {
 		for(String tok : infotoks.split(";")) {
 			if (tok.startsWith("END=")) {
-				return tok.replace("END=", "");
+				return tok;
 			}
 		}
 		return ".";

--- a/src/main/java/operator/snpeff/SnpEffGeneAnnotate.java
+++ b/src/main/java/operator/snpeff/SnpEffGeneAnnotate.java
@@ -130,7 +130,7 @@ public class SnpEffGeneAnnotate extends Annotator {
 				List<SnpEffInfo> newInfos = parseOutputLineVCF(line);
 				String[] toks = line.split("\t");
 				
-				String varKey = convertVar(toks[0], Integer.parseInt(toks[1]),toks[3], toks[4], ".");
+				String varKey = convertVar(toks[0], Integer.parseInt(toks[1]),toks[3], toks[4], findInfoEndFromVCF(toks[7]));
 				List<SnpEffInfo> infos = annos.get(varKey);
 				if (infos == null) {
 					infos = new ArrayList<SnpEffInfo>();
@@ -150,7 +150,20 @@ public class SnpEffGeneAnnotate extends Annotator {
 
 	}
 	
-
+	/**
+	 * InfoToks should be field 7 from a VCF record (the INFO column), we split this into tokens on ; and search for the END field,
+	 * If found return it, otherwise return '.'
+	 * @return Either the END entry from the INFO field, or "." if no END found
+	 */
+	private String findInfoEndFromVCF(String infotoks) {
+		for(String tok : infotoks.split(";")) {
+			if (tok.startsWith("END=")) {
+				return tok.replace("END=", "");
+			}
+		}
+		return ".";
+	}
+	
 	@Override
 	public void annotateVariant(VariantRec var) throws OperationFailedException {
 		
@@ -159,7 +172,7 @@ public class SnpEffGeneAnnotate extends Annotator {
 			
 		}
 		
-		String varStr = convertVar(var);
+		String varStr = convertVarWithInfoEND(var);
 		String[] allAlts = varStr.split("\n");
 		
 		//crashes if one of the alts has no annotations

--- a/src/main/java/pipeline/Pipeline.java
+++ b/src/main/java/pipeline/Pipeline.java
@@ -48,7 +48,7 @@ import util.text.QueuedLogHandler;
  */
 public class Pipeline {
 
-	public static final String PIPELINE_VERSION = "1.9.15";
+	public static final String PIPELINE_VERSION = "1.9.16";
 	protected File source;
 	protected Document xmlDoc;
 	public static final String PROJECT_HOME="home";

--- a/src/test/java/annotation/testSnpEff5.xml
+++ b/src/test/java/annotation/testSnpEff5.xml
@@ -1,0 +1,18 @@
+
+<Pipeline>
+
+<InputVCF class="buffer.VCFFile" filename="src/test/java/testvcfs/neardups.vcf" />
+
+<VariantPool class="buffer.variant.VariantPool">
+	<InputVCF />
+</VariantPool>
+
+
+<GeneAnnotate class="operator.snpeff.SnpEffGeneAnnotate" snpeff.genome="hg19_arup_January_05_2017" updownstream.length="100">
+	<VariantPool />
+</GeneAnnotate>
+
+
+
+
+</Pipeline>

--- a/src/test/java/testvcfs/neardups.vcf
+++ b/src/test/java/testvcfs/neardups.vcf
@@ -1,0 +1,167 @@
+##fileformat=VCFv4.2
+##ALT=<ID=BND,Description="Translocation Breakend">
+##ALT=<ID=DEL,Description="Deletion">
+##ALT=<ID=DUP:TANDEM,Description="Tandem Duplication">
+##ALT=<ID=INS,Description="Insertion">
+##ALT=<ID=INV,Description="Inversion">
+##FILTER=<ID=HighAltCnt,Description="high alternative allele count (>1000000)">
+##FILTER=<ID=HighChi2score,Description="high chi-squared score (>20)">
+##FILTER=<ID=HighCov,Description="high coverage (>1000000)">
+##FILTER=<ID=LowAltCnt,Description="low alternative allele count (<5)">
+##FILTER=<ID=LowChi2score,Description="low chi-squared score (<0)">
+##FILTER=<ID=LowCov,Description="low coverage (<5)">
+##FILTER=<ID=LowVaf,Description="low variant allele frequency (<0.05)">
+##FILTER=<ID=MS,Description="Microsatellite mutation (format: #LEN#MOTIF)">
+##FILTER=<ID=MaxMQ0Frac,Description="For a small variant (<1000 base), the fraction of reads with MAPQ0 around either breakend exceeds 0.4">
+##FILTER=<ID=min_dp_10,Description="Minimum Coverage 10">
+##FILTER=<ID=min_indelqual_20,Description="Minimum Indel Quality (Phred) 20">
+##FILTER=<ID=min_snvqual_52,Description="Minimum SNV Quality (Phred) 52">
+##FILTER=<ID=min_snvqual_79,Description="Minimum SNV Quality (Phred) 79">
+##FILTER=<ID=sb_fdr,Description="Strand-Bias Multiple Testing Correction: fdr corr. pvalue > 0.001000">
+##FORMAT=<ID=AD,Number=R,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed">
+##FORMAT=<ID=AF,Number=1,Type=Float,Description="Allele Frequency">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="k-mer Depth">
+##FORMAT=<ID=DP4,Number=4,Type=Integer,Description="Counts for ref-forward bases, ref-reverse, alt-forward and alt-reverse bases">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=PR,Number=.,Type=Integer,Description="Spanning paired-read support for the ref and alt alleles in the order listed">
+##FORMAT=<ID=SR,Number=.,Type=Integer,Description="Split reads for the ref and alt alleles in the order listed, for reads where P(allele|read)>0.999">
+##GATKCommandLine.CombineVariants=<ID=CombineVariants,Version=3.6-0-g89b7209,Date="Wed Jan 11 21:25:31 UTC 2017",Epoch=1484169931818,CommandLineOptions="analysis_type=CombineVariants input_file=[] showFullBamList=false read_buffer_size=null read_filter=[] disable_read_filter=[] intervals=null excludeIntervals=null interval_set_rule=UNION interval_merging=ALL interval_padding=0 reference_sequence=/docker/reference/Data/B37/GATKBundle/2.8_subset_arup_v0.1/human_g1k_v37_decoy_phiXAdaptr.fasta nonDeterministicRandomSeed=false disableDithering=false maxRuntime=-1 maxRuntimeUnits=MINUTES downsampling_type=BY_SAMPLE downsample_to_fraction=null downsample_to_coverage=1000 baq=OFF baqGapOpenPenalty=40.0 refactor_NDN_cigar_string=false fix_misencoded_quality_scores=false allow_potentially_misencoded_quality_scores=false useOriginalQualities=false defaultBaseQualities=-1 performanceLog=null BQSR=null quantize_quals=0 static_quantized_quals=null round_down_quantized=false disable_indel_quals=false emit_original_quals=false preserve_qscores_less_than=6 globalQScorePrior=-1.0 validation_strictness=SILENT remove_program_records=false keep_program_records=false sample_rename_mapping_file=null unsafe=null disable_auto_index_creation_and_locking_when_reading_rods=false no_cmdline_in_header=false sites_only=false never_trim_vcf_format_field=false bcf=false bam_compression=null simplifyBAM=false disable_bam_indexing=false generate_md5=false num_threads=8 num_cpu_threads_per_data_thread=1 num_io_threads=0 monitorThreadEfficiency=false num_bam_file_handles=null read_group_black_list=null pedigree=[] pedigreeString=[] pedigreeValidationType=STRICT allow_intervals_with_unindexed_bam=false generateShadowBCF=false variant_index_type=DYNAMIC_SEEK variant_index_parameter=-1 reference_window_stop=0 phone_home= gatk_key=null tag=NA logging_level=INFO log_to_file=null help=false version=false variant=[(RodBindingCollection [(RodBinding name=variant source=VCF/Lofreq/11111400191_2011120_000000000_ABYN5_lofreq_genotypes.vcf)] ), (RodBindingCollection [(RodBinding name=variant2 source=VCF/Manta-11111400191_2011120_000000000_ABYN5/results/variants/tumorS V_filter.vcf)]), (RodBindingCollection [(RodBinding name=variant3 source=VCF/Scalpel-11111400191_2011120_000000000_ABYN5/variants_filter.indel .vcf)])] out=/docker/working/741d74b1-93f3-45b4-89e1-2e024648bc82/VCF/11111400191_201 1120_000000000_ABYN5_all_variants_raw.vcf genotypemergeoption=UNSORTED filteredrecordsmergetype=KEEP_IF_ANY_UNFILTERED multipleallelesmergetype=BY_TYPE rod_priority_list=null printComplexMerges=false filteredAreUncalled=false minimalVCF=false excludeNonVariants=false setKey=set assumeIdenticalSamples=true minimumN=1 suppressCommandLineHeader=false mergeInfoWithMaxAC=false filter_reads_with_N_cigar=false filter_mismatching_base_and_quals=false filter_bases_not_stored=false">
+##GATKCommandLine.SelectVariants=<ID=SelectV ariants,Version=3.6-0-g89b7209,Date="Wed Jan 11 21:26:21 UTC 2017",Epoch=1484169981252,CommandLineOptions="analysis_type=SelectVariants input_file=[] showFullBamList=false read_buffer_size=null read_filter=[] disable_read_filter=[] intervals=[11111400191_2011120_000000000_ABYN5-padded_probes_MedianInsertSiz e.bed] excludeIntervals=null interval_set_rule=UNION interval_merging=ALL interval_padding=0 reference_sequence=/docker/reference/Data/B37/GATKBundle/2.8_subset_arup_v0. 1/human_g1k_v37_decoy_phiXAdaptr.fasta nonDeterministicRandomSeed=false disableDithering=false maxRuntime=-1 maxRuntimeUnits=MINUTES downsampling_type=BY_SAMPLE downsample_to_fraction=null downsample_to_coverage=1000 baq=OFF baqGapOpenPenalty=40.0 refactor_NDN_cigar_string=false fix_misencoded_quality_scores=false allow_potentially_misencoded_quality_scores=false useOriginalQualities=false defaultBaseQualities=-1 performanceLog=null BQSR=null quantize_quals=0 static_quantized_quals=null round_down_quantized=false disable_indel_quals=false emit_original_quals=false preserve_qscores_less_than=6 globalQScorePrior=-1.0 validation_strictness=SILENT remove_program_records=false keep_program_records=false sample_rename_mapping_file=null unsafe=null disable_auto_index_creation_and_locking_when_reading_rods=false no_cmdline_in_header=false sites_only=false never_trim_vcf_format_field=false bcf=false bam_compression=null simplifyBAM=false disable_bam_indexing=false generate_md5=false num_threads=1 num_cpu_threads_per_data_thread=1 num_io_threads=0 monitorThreadEfficiency=false num_bam_file_handles=null read_group_black_list=null pedigree=[] pedigreeString=[] pedigreeValidationType=STRICT allow_intervals_with_unindexed_bam=false generateShadowBCF=false variant_index_type=DYNAMIC_SEEK variant_index_parameter=-1 reference_window_stop=0 phone_home= gatk_key=null tag=NA logging_level=INFO log_to_file=null help=false version=false variant=(RodBinding name=variant source=VCF/11111400191_2011120_000000000_ABYN5_all_variants_raw.vcf) discordance=(RodBinding name= source=UNBOUND) concordance=(RodBinding name= source=UNBOUND) out=/docker/working/741d74b1-93f3-45b4-89e1-2e024648bc82/VCF/11111400191_201 1120_000000000_ABYN5_final_variants.vcf sample_name=[] sample_expressions=null sample_file=null exclude_sample_name=[] exclude_sample_file=[] exclude_sample_expressions=[] selectexpressions=[] invertselect=false excludeNonVariants=false excludeFiltered=false preserveAlleles=false removeUnusedAlternates=false restrictAllelesTo=ALL keepOriginalAC=false keepOriginalDP=false mendelianViolation=false invertMendelianViolation=false mendelianViolationQualThreshold=0.0 select_random_fraction=0.0 remove_fraction_genotypes=0.0 selectTypeToInclude=[] selectTypeToExclude=[] keepIDs=null excludeIDs=null fullyDecode=false justRead=false maxIndelSize=2147483647 minIndelSize=0 maxFilteredGenotypes=2147483647 minFilteredGenotypes=0 maxFractionFilteredGenotypes=1.0 minFractionFilteredGenotypes=0.0 maxNOCALLnumber=2147483647 maxNOCALLfraction=1.0 setFilteredGtToNocall=false ALLOW_NONOVERLAPPING_COMMAND_LINE_SAMPLES=false forceValidOutput=false filter_reads_with_N_cigar=false filter_mismatching_base_and_quals=false filter_bases_not_stored=false">
+##INFO=<ID=AC,Number=A,Type=Integer,Descript ion="Allele count in genotypes, for each ALT allele, in the same order as  listed">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency, for each ALT allele, in the same order as listed">
+##INFO=<ID=ALTCOV,Number=1,Type=Integer,Description="k-mer coverage of reference + any other allele (different from current non-reference) at locus">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=AVGCOV,Number=1,Type=Float,Description="average k-mer coverage">
+##INFO=<ID=BESTSTATE,Number=1,Type=String,Description="state of the mutation">
+##INFO=<ID=BND_DEPTH,Number=1,Type=Integer,Description="Read depth at local translocation breakend">
+##INFO=<ID=CHI2,Number=1,Type=Float,Description="chi-square score">
+##INFO=<ID=CIEND,Number=2,Type=Integer,Description="Confidence interval around END">
+##INFO=<ID=CIGAR,Number=A,Type=String,Description="CIGAR alignment for each alternate indel allele">
+##INFO=<ID=CIPOS,Number=2,Type=Integer,Description="Confidence interval around POS">
+##INFO=<ID=CONSVAR,Number=0,Type=Flag,Description="Indicates that the variant is a consensus variant (as opposed to a low frequency variant).">
+##INFO=<ID=COVRATIO,Number=1,Type=Float,Description="coverage ratio [(MINCOV)/(ALTCOV+MINCOV)]">
+##INFO=<ID=COVSTATE,Number=1,Type=String,Descri ption="coverage state of the mutation">
+##INFO=<ID=DENOVO,Number=0,Type=Flag,Description="De novo mutation">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Raw Depth">
+##INFO=<ID=DP4,Number=4,Type=Integer,Description="Counts for ref-forward bases, ref-reverse, alt-forward and alt-reverse bases">
+##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the variant described in this record">
+##INFO=<ID=EVENT,Number=1,Type=String,Description="ID of event associated to breakend">
+##INFO=<ID=FISHERPHREDSCORE,Number=1,Type=Float,Description="phre d-scaled p-value from the Fisher's exact test for tumor-normal allele counts">
+##INFO=<ID=HOMLEN,Number=.,Type=Integer,Description="Length of base pair identical homology at event breakpoints">
+##INFO=<ID=HOMSEQ,Number=.,Type=String,Description="Sequence of base pair identical homology at event breakpoints">
+##INFO=<ID=HRUN,Number=1,Type=Integer,Description="Homopolymer length to the right of report indel position">
+##INFO=<ID=IMPRECISE,Number=0,Type=Flag,Description="Imprecise structural variation">
+##INFO=<ID=INDEL,Number=0,Type=Flag,Description="Indicates that the variant is an INDEL.">
+##INFO=<ID=INH,Number=1,Type=String,Description="inheritance">
+##INFO=<ID=INV3,Number=0,Type=Flag,Description="Inversion breakends open 3' of reported location">
+##INFO=<ID=INV5,Number=0,Type=Flag,Description="Inversion breakends open 5' of reported location">
+##INFO=<ID=LEFT_SVINSSEQ,Number=.,Type=String,Description="Known left side of insertion for an insertion of unknown length">
+##INFO=<ID=MATEID,Number=.,Type=String,Description="ID of mate breakend">
+##INFO=<ID=MATE_BND_DEPTH,Number=1,Type=Integer,Description="Read depth at remote translocation mate breakend">
+##INFO=<ID=MINCOV,Number=1,Type=Integer,Description="minimum k-mer coverage of non-reference allele">
+##INFO=<ID=RIGHT_SVINSSEQ,Number=.,Type=String,Description="Known right side of insertion for an insertion of unknown length">
+##INFO=<ID=SB,Number=1,Type=Float,Description="Strand Bias">
+##INFO=<ID=SOMATIC,Number=0,Type=Flag,Description="Somatic mutation">
+##INFO=<ID=SVINSLEN,Number=.,Type=Integer,Description="Length of insertion">
+##INFO=<ID=SVINSSEQ,Number=.,Type=String,Description="Sequence of insertion">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Difference in length between REF and ALT alleles">
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##INFO=<ID=ZYG,Number=1,Type=String,Description="zygosity">
+##INFO=<ID=set,Number=1,Type=String,Description="Source VCF for the merged record in CombineVariants">
+##cmdline=/home/arup/conda/envs/soma_vc/share/manta-1.0.0- 0/bin/configManta.py --config /docker/reference/Data/Manta/1.0.0/configManta.py.ini --tumorBam GATK_11111400191_2011120_000000000_ABYN5/11111400191_2011120_000000000_ABYN5 .final.bam --referenceFasta /docker/reference/Data/B37/GATKBundle/2.8_subset_arup_v0.1/human_g1k_v37_dec oy_phiXAdaptr.fasta --exome --runDir VCF/Manta-11111400191_2011120_000000000_ABYN5
+##contig=<ID=1,length=249250621,assembly=b37>
+##contig=<ID=2,length=243199373,assembly=b37>
+##contig=<ID=3 ,length=198022430,assembly=b37>
+##contig=<ID=4,length=191154276,assembly=b37 >
+##contig=<ID=5,length=180915260,assembly=b37>
+##contig=<ID=6,length=171115067,assembly=b37>
+##contig=<ID=7,length=159138663,assembly=b37>
+##contig=<ID=8,length=146364022,assembly=b37>
+##contig=<ID=9,length=141213431,assembly=b37>
+##contig=<ID=10,length=135534747,assembly=b37>
+##contig=<ID=11,length=13 5006516,assembly=b37>
+##contig=<ID=12,length=133851895,assembly=b37>
+##contig=<ID=13,length=115169878,assembly=b37>
+##contig=<ID=14,length=107349540,assembly=b37>
+##contig=<ID=15,length=102531392,assembly=b37>
+##contig=<ID=16,length=90354753,assembly=b37>
+##contig=<ID=17,length=81195210,assembly=b37>
+##contig=<ID=18,length=78077248,assembly=b37>
+##contig=<ID=19,length=59128983, assembly=b37>
+##contig=<ID=20,length=63025520,assembly=b37>
+##contig=<ID=21,length=48129895,assembly=b37>
+##contig=<ID=22,length=51304566,assembly=b37>
+##contig=<ID=X,length=155270560,assembly=b37>
+##contig=<ID=Y,length=59373566 ,assembly=b37>
+##contig=<ID=MT,length=16569,assembly=b37>
+##contig=<ID=GL000207.1,length=4262,assembly=b37>
+##contig=<ID=GL000226.1,length=15008,assembly=b37>
+##contig=<ID=GL000229.1,length=19913,assembly=b37>
+##contig=<ID=GL000231.1,length=27386,assembly=b37>
+##contig=<ID=GL000210.1,length=27682,assembly=b37>
+##contig=<ID=GL000239.1,length=33824,assembly=b37>
+##contig=<ID=GL000235.1,length=34474,assembly=b37>
+##contig=<ID=GL000201.1,length=36148,assembly=b37>
+##contig=<ID=GL000247.1,length=36422,assembly=b37>
+##contig=<ID=GL000245.1,length=36651,assembly=b37>
+##contig=<ID=GL000197.1,length=37175,assembly=b37>
+##contig=<ID=GL000203.1,length=37498,assembly=b37>
+##contig=<ID=GL000246.1,length=38154,assembly=b37>
+##contig=<ID=GL000249.1,length=38502,assembly=b37>
+##contig=<ID=GL000196.1,length=38914,assembly=b37>
+##contig=<ID=GL000248.1,length=39786,assembly=b37>
+##contig=<ID=GL000244.1,length=39929,assembly=b37>
+##contig=<ID=GL000238.1,length=39939,assembly=b37>
+##contig=<ID=GL000202.1,length=40103,assembly=b37>
+##contig=<ID=GL000234.1,length=40531,assembly=b37>
+##contig=<ID=GL000232.1,length=40652,assembly=b37>
+##contig=<ID=GL000206.1,length=41001,assembly=b37>
+##contig=<ID=GL000240.1,length=41933, assembly=b37>
+##contig=<ID=GL000236.1,length=41934,assembly=b37>
+##contig=<ID=GL000241.1,length=42152,assembly=b37>
+##contig=<ID=GL000243.1,length=43341 ,assembly=b37>
+##contig=<ID=GL000242.1,length=43523,assembly=b37>
+##contig=<ID=GL000230.1,length=43691,assembly=b37>
+##contig=<ID=GL000237.1,length=45867,assembly=b37>
+##contig=<ID=GL000233.1,length=45941,assembly=b37>
+##contig=<ID=GL000204.1,length=81310,assembly=b37>
+##contig=<ID=GL000198.1,length=900 85,assembly=b37>
+##contig=<ID=GL000208.1,length=92689,assembly=b37>
+##contig=<ID=GL000191.1,length=106433,assembly=b37>
+##contig=<ID=GL000227.1,length=128374,assembly=b37>
+##contig=<ID=GL000228.1,length=129120,assembly=b37>
+##contig=<ID=GL000214.1,length=137718,assembly=b37>
+##contig=<ID=GL000221.1,length=155397,assembly=b37>
+##contig=<ID=GL000209.1,length=159169,assembly=b37>
+##contig=<ID=GL000218.1,length=161147,assembly=b37>
+##contig=<ID=GL000220.1, length=161802,assembly=b37>
+##contig=<ID=GL000213.1,length=164239,assembly=b 37>
+##contig=<ID=GL000211.1,length=166566,assembly=b37>
+##contig=<ID=GL00019 9.1,length=169874,assembly=b37>
+##contig=<ID=GL000217.1,length=172149,assembly=b37>
+##contig=<ID=GL000216.1,length=172294,assembly=b37>
+##contig=<ID=GL0 00205.1,length=174588,assembly=b37>
+##contig=<ID=GL000219.1,length=179198,assembly=b37>
+##contig=<ID=GL000224.1,length=179693,assembly=b37>
+##contig=<ID=GL000223.1,length=180455,assembly=b37>
+##contig=<ID=GL000195.1,length=18289 6,assembly=b37>
+##contig=<ID=GL000212.1,length=186858,assembly=b37>
+##contig=<ID=GL000222.1,length=186861,assembly=b37>
+##contig=<ID=GL000200.1,length=1 87035,assembly=b37>
+##contig=<ID=GL000193.1,length=189789,assembly=b37>
+##contig=<ID=GL000194.1,length=191469,assembly=b37>
+##contig=<ID=GL000225.1,leng th=211173,assembly=b37>
+##contig=<ID=GL000192.1,length=547496,assembly=b37>
+##contig=<ID=NC_007605,length=171823,assembly=b37>
+##contig=<ID=hs37d5,lengt h=35477943,assembly=b37>
+##contig=<ID=chrAdapter,length=6987,assembly=b37>
+##contig=<ID=chrPhiX_Illumina,length=5386,assembly=b37>
+##fileDate=20170111
+##reference=file:///docker/reference/Data/B37/GATKBundle/2.8_subset_arup_v0.1/human_g1k_v37_decoy_phiXAdaptr.fasta
+##source=lofreq_scalpel_manta
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	11111400191_2011120_000000000_ABYN5
+10	89653800	MantaDEL:1:111:112:0:0:0	A	<DEL>	.	PASS	END=89653803;SVTYPE=DEL;SVLEN=3;IMPRECISE;CIPOS=-36,36;CIEND=-37,38;set=manta	PR	98,3
+10	89653800	MantaDEL:1:111:112:0:0:0	A	<DEL>	.	PASS	END=89653807;SVTYPE=DEL;SVLEN=7;IMPRECISE;CIPOS=-36,36;CIEND=-37,38;set=manta	PR	98,3
+13	28608224	MantaDUP:TANDEM:0:2261:2261:7:1:0	T	<DUP:TANDEM>	.	PASS	AF=0.033;END=28608230;SVINSLEN=6;SVINSSEQ=CAGTCGTACGGAC;SVLEN=92;SVTYPE=DUP;set=manta	PR:SR	1289,81:4757,125
+13	28608224	MantaDUP:TANDEM:0:2261:2261:7:1:0	T	<DUP:TANDEM>	.	PASS	AF=0.033;END=28608240;SVINSLEN=16;SVINSSEQ=CAGTCGTACGGAC;SVLEN=92;SVTYPE=DUP;set=manta	PR:SR	1289,81:4757,125
+


### PR DESCRIPTION
This fixes a serious issue in SnpEff annotation in which variants with symbolic alts that started at the same position but had different lengths got incorrect SnpEff annotations (since SnpEff does chrom / pos/ ref/ alt matching). 