### PR TITLE
Parse strand bias from Pipey vcf files

### DIFF
--- a/src/main/java/operator/writer/VarViewerWriter.java
+++ b/src/main/java/operator/writer/VarViewerWriter.java
@@ -73,6 +73,7 @@ public class VarViewerWriter extends VariantPoolWriter {
 			VariantRec.COSMIC_ID,
 			VariantRec.COSMIC_COUNT,
 			VariantRec.UK10K_ALLELE_FREQ,
+			VariantRec.FS_SCORE,//strand bias
 			//=========================================================
 			//Exac columns, 32 of them. 4 for overall, and 4 for each of the 7 populations.
 			VariantRec.EXAC63K_VERSION,


### PR DESCRIPTION
Code to parse stand bias from Pipey VCF files was written in the VCF parser, but the code to push the value to the annotated csv and json files was never added to the VarViewerWriter class