### PR TITLE
Adding strand bias annotation from Pipey VCF files

### DIFF
--- a/src/main/java/operator/writer/VarViewerWriter.java
+++ b/src/main/java/operator/writer/VarViewerWriter.java
@@ -83,6 +83,7 @@ public class VarViewerWriter extends VariantPoolWriter {
 			VariantRec.BAD_REGION,
 			VariantRec.LOW_COMPLEX_REGION,
 			VariantRec.VAR_CALLER,
+			VariantRec.FS_SCORE,
 			//=========================================================
 			//Exac columns, 32 of them. 4 for overall, and 4 for each of the 7 populations.
 			VariantRec.EXAC63K_VERSION,


### PR DESCRIPTION
Code to parse strand bias ("FS_SCORE") from Pipey VCFs was written but never pushed to the final class that puts the annotation into the json file.