### PR TITLE
Bus 756 snpeff splice

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.aruplab.ngs</groupId>
   <artifactId>Pipeline</artifactId>
   <packaging>jar</packaging>
-  <version>1.9.21</version>
+  <version>1.9.22</version>
   <name>Pipeline</name>
   <url>http://maven.apache.org</url>
   <properties>

--- a/src/main/java/operator/snpeff/SnpEffGeneAnnotate.java
+++ b/src/main/java/operator/snpeff/SnpEffGeneAnnotate.java
@@ -107,7 +107,7 @@ public class SnpEffGeneAnnotate extends Annotator {
 		//Next, run snpeff using the input file we just made (--formatEff tag used for v4.0 output standards while running v4.2)
 		String command = javaHome + " -Xmx16g -jar " + snpEffDir + "/snpEff.jar -c " + snpEffDir + 
 				"/snpEff.config " + snpEffGenome + " -hgvs -nostats -ud " + updownStreamLength + 
-				" -spliceSiteSize " + spliceSiteSize + " " + input.getAbsolutePath();
+				" " + input.getAbsolutePath();
 		
 		Logger.getLogger(Pipeline.primaryLoggerName).info("Executing command: " + command);
 		try {

--- a/src/main/java/pipeline/Pipeline.java
+++ b/src/main/java/pipeline/Pipeline.java
@@ -48,7 +48,7 @@ import util.text.QueuedLogHandler;
  */
 public class Pipeline {
 
-	public static final String PIPELINE_VERSION = "1.9.21";
+	public static final String PIPELINE_VERSION = "1.9.22";
 	protected File source;
 	protected Document xmlDoc;
 	public static final String PROJECT_HOME="home";

--- a/src/test/java/annotation/TestSnpEff.java
+++ b/src/test/java/annotation/TestSnpEff.java
@@ -31,6 +31,7 @@ public class TestSnpEff extends TestCase {
 	File inputFile3 = new File("src/test/java/annotation/testSnpEff3.xml");
     File inputFile4 = new File("src/test/java/annotation/testSnpEff4.xml");
     File inputFile5 = new File("src/test/java/annotation/testSnpEff5.xml");
+    File inputFileSplice = new File("src/test/java/annotation/testSnpEffSplice.xml");
 	File propertiesFile = new File("src/test/java/core/inputFiles/testProperties.xml");
 	File snpEffDir = null;
 
@@ -136,6 +137,103 @@ public class TestSnpEff extends TestCase {
 		}
 
 	}
+
+	public void testSplice() {
+
+		Pipeline ppl;
+                ppl = this.preparePipeline(inputFileSplice);
+                 
+		try {
+
+			ppl.initializePipeline();
+			ppl.stopAllLogging();
+
+			ppl.execute();
+
+			//Grab the snpEff annotator - we'll take a look at the variants to make sure
+			//they're ok
+			SnpEffGeneAnnotate annotator = (SnpEffGeneAnnotate)ppl.getObjectHandler().getObjectForLabel("GeneAnnotate");
+			VariantPool vars = annotator.getVariants();
+			Assert.assertTrue(vars.size() == 8);
+
+			VariantRec var = vars.findRecord("13", 32921034, "G", "A");
+			Assert.assertTrue(var != null);
+			JSONArray snpeff_annos = var.getjsonProperty(VariantRec.SNPEFF_ALL);
+			JSONObject hit = findJsonObj(snpeff_annos, "NM_000059.3.1");
+			Assert.assertNotNull(hit);
+			Assert.assertTrue(hit.has(VariantRec.VARIANT_TYPE));
+			Assert.assertTrue(hit.get(VariantRec.VARIANT_TYPE).equals("splice_donor_variant&intron_variant"));
+			Assert.assertTrue(hit.get(VariantRec.GENE_NAME).equals("BRCA2"));
+			
+			
+			var = vars.findRecord("13", 32921035, "T", "A");
+			Assert.assertTrue(var != null);
+			snpeff_annos = var.getjsonProperty(VariantRec.SNPEFF_ALL);
+			hit = findJsonObj(snpeff_annos, "NM_000059.3.1");
+			Assert.assertNotNull(hit);
+			Assert.assertTrue(hit.has(VariantRec.VARIANT_TYPE));
+			Assert.assertTrue(hit.get(VariantRec.VARIANT_TYPE).equals("splice_donor_variant&intron_variant"));
+			Assert.assertTrue(hit.get(VariantRec.GENE_NAME).equals("BRCA2"));
+			
+			
+			var = vars.findRecord("13", 32921036, "A", "G");
+			Assert.assertTrue(var != null);
+			snpeff_annos = var.getjsonProperty(VariantRec.SNPEFF_ALL);
+			hit = findJsonObj(snpeff_annos, "NM_000059.3.1");
+			Assert.assertNotNull(hit);
+			Assert.assertTrue(hit.has(VariantRec.VARIANT_TYPE));
+			Assert.assertTrue(hit.get(VariantRec.VARIANT_TYPE).equals("splice_region_variant&intron_variant"));
+			Assert.assertTrue(hit.get(VariantRec.GENE_NAME).equals("BRCA2"));
+			
+			var = vars.findRecord("13", 32921041, "A", "G");
+			Assert.assertTrue(var != null);
+			snpeff_annos = var.getjsonProperty(VariantRec.SNPEFF_ALL);
+			hit = findJsonObj(snpeff_annos, "NM_000059.3.1");
+			Assert.assertNotNull(hit);
+			Assert.assertTrue(hit.has(VariantRec.VARIANT_TYPE));
+			Assert.assertTrue(hit.get(VariantRec.VARIANT_TYPE).equals("splice_region_variant&intron_variant"));
+			Assert.assertTrue(hit.get(VariantRec.GENE_NAME).equals("BRCA2"));
+			
+			var = vars.findRecord("13", 32921042, "T", "G");
+			Assert.assertTrue(var != null);
+			snpeff_annos = var.getjsonProperty(VariantRec.SNPEFF_ALL);
+			hit = findJsonObj(snpeff_annos, "NM_000059.3.1");
+			Assert.assertNotNull(hit);
+			Assert.assertTrue(hit.has(VariantRec.VARIANT_TYPE));
+			Assert.assertTrue(hit.get(VariantRec.VARIANT_TYPE).equals("intron_variant"));
+			Assert.assertTrue(hit.get(VariantRec.GENE_NAME).equals("BRCA2"));
+			
+			
+			var = vars.findRecord("13", 32920963, "G", "A");
+			Assert.assertTrue(var != null);
+			snpeff_annos = var.getjsonProperty(VariantRec.SNPEFF_ALL);
+			hit = findJsonObj(snpeff_annos, "NM_000059.3.1");
+			Assert.assertNotNull(hit);
+			Assert.assertTrue(hit.has(VariantRec.VARIANT_TYPE));
+			Assert.assertTrue(hit.get(VariantRec.VARIANT_TYPE).equals("splice_acceptor_variant&intron_variant"));
+			
+			var = vars.findRecord("13", 32920962, "A", "T");
+			Assert.assertTrue(var != null);
+			snpeff_annos = var.getjsonProperty(VariantRec.SNPEFF_ALL);
+			hit = findJsonObj(snpeff_annos, "NM_000059.3.1");
+			Assert.assertNotNull(hit);
+			Assert.assertTrue(hit.has(VariantRec.VARIANT_TYPE));
+			Assert.assertTrue(hit.get(VariantRec.VARIANT_TYPE).equals("splice_acceptor_variant&intron_variant"));
+			
+			var = vars.findRecord("13", 32920961, "T", "G");
+			Assert.assertTrue(var != null);
+			snpeff_annos = var.getjsonProperty(VariantRec.SNPEFF_ALL);
+			hit = findJsonObj(snpeff_annos, "NM_000059.3.1");
+			Assert.assertNotNull(hit);
+			Assert.assertTrue(hit.has(VariantRec.VARIANT_TYPE));
+			Assert.assertTrue(hit.get(VariantRec.VARIANT_TYPE).equals("splice_region_variant&intron_variant"));
+			
+		}  catch (Exception ex) {
+			ex.printStackTrace();
+			Assert.assertTrue(false);
+		} 
+	}
+	
 	
 	public void testSnpEff() {
 

--- a/src/test/java/annotation/TestSnpEff.java
+++ b/src/test/java/annotation/TestSnpEff.java
@@ -288,7 +288,7 @@ public class TestSnpEff extends TestCase {
 			SnpEffGeneAnnotate annotator = (SnpEffGeneAnnotate)ppl.getObjectHandler().getObjectForLabel("GeneAnnotate");
 			VariantPool vars = annotator.getVariants();
 			int x = vars.size();
-			Assert.assertTrue(vars.size() == 6);
+			Assert.assertTrue(vars.size() == 13);
 
 			VariantRec var = vars.findRecord("1", 24201919, "T", "C");
 			Assert.assertTrue(var != null); 

--- a/src/test/java/annotation/TestSnpEff.java
+++ b/src/test/java/annotation/TestSnpEff.java
@@ -189,6 +189,7 @@ public class TestSnpEff extends TestCase {
 
 			SnpEffGeneAnnotate annotator = (SnpEffGeneAnnotate)ppl.getObjectHandler().getObjectForLabel("GeneAnnotate");
 			VariantPool vars = annotator.getVariants();
+			int x = vars.size();
 			Assert.assertTrue(vars.size() == 6);
 
 			VariantRec var = vars.findRecord("1", 24201919, "T", "C");

--- a/src/test/java/annotation/testSnpEffSplice.xml
+++ b/src/test/java/annotation/testSnpEffSplice.xml
@@ -1,0 +1,19 @@
+
+<!-- Uses annovar to annotate the given VCF file. This will produce lots of different output files... -->
+<Pipeline>
+
+<InputVCF class="buffer.VCFFile" filename="src/test/java/testvcfs/testSplice.vcf" />
+
+<VariantPool class="buffer.variant.VariantPool">
+	<InputVCF />
+</VariantPool>
+
+
+<GeneAnnotate class="operator.snpeff.SnpEffGeneAnnotate" snpeff.genome="hg19_arup_January_05_2017" updownstream.length="100">
+	<VariantPool />
+</GeneAnnotate>
+
+
+
+
+</Pipeline>

--- a/src/test/java/testvcfs/testSplice.vcf
+++ b/src/test/java/testvcfs/testSplice.vcf
@@ -1,0 +1,119 @@
+##fileformat=VCFv4.1
+##FILTER=<ID=LowQual,Description="Low quality">
+##FORMAT=<ID=AD,Number=.,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth (reads with MQ=255 or with bad mates are filtered)">
+##FORMAT=<ID=GQ,Number=1,Type=Float,Description="Genotype Quality">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=PL,Number=G,Type=Integer,Description="Normalized, Phred-scaled likelihoods for genotypes as defined in the VCF specification">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency, for each ALT allele, in the same order as listed">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=BaseQRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt Vs. Ref base qualities">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth; some reads may have been filtered">
+##INFO=<ID=DS,Number=0,Type=Flag,Description="Were any of the samples downsampled?">
+##INFO=<ID=Dels,Number=1,Type=Float,Description="Fraction of Reads Containing Spanning Deletions">
+##INFO=<ID=FS,Number=1,Type=Float,Description="Phred-scaled p-value using Fisher's exact test to detect strand bias">
+##INFO=<ID=HRun,Number=1,Type=Integer,Description="Largest Contiguous Homopolymer Run of Variant Allele In Either Direction">
+##INFO=<ID=HaplotypeScore,Number=1,Type=Float,Description="Consistency of the site with at most two segregating haplotypes">
+##INFO=<ID=InbreedingCoeff,Number=1,Type=Float,Description="Inbreeding coefficient as estimated from the genotype likelihoods per-sample when compared against the Hardy-Weinberg expectation">
+##INFO=<ID=MQ,Number=1,Type=Float,Description="RMS Mapping Quality">
+##INFO=<ID=MQ0,Number=1,Type=Integer,Description="Total Mapping Quality Zero Reads">
+##INFO=<ID=MQRankSum,Number=1,Type=Float,Description="Z-score From Wilcoxon rank sum test of Alt vs. Ref read mapping qualities">
+##INFO=<ID=QD,Number=1,Type=Float,Description="Variant Confidence/Quality by Depth">
+##INFO=<ID=ReadPosRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt vs. Ref read position bias">
+##INFO=<ID=SB,Number=1,Type=Float,Description="Strand Bias">
+##UnifiedGenotyper="analysis_type=UnifiedGenotyper input_file=[/mnt/research1/jobwrangler/completed/Philippe/myeloidmalig_run4/U-30_nodedup.workingdir/U-30_nodedup.final.bam] read_buffer_size=null phone_home=STANDARD gatk_key=null read_filter=[BadCigar] intervals=[/mnt/research1/reference/myeloidmalig_sureselect.bed] excludeIntervals=null interval_set_rule=UNION interval_merging=ALL reference_sequence=/mnt/research1/reference/human_g1k_v37.fasta nonDeterministicRandomSeed=false downsampling_type=BY_SAMPLE downsample_to_fraction=null downsample_to_coverage=100000 baq=OFF baqGapOpenPenalty=40.0 performanceLog=null useOriginalQualities=false BQSR=null quantize_quals=-1 defaultBaseQualities=-1 validation_strictness=SILENT unsafe=null num_threads=10 num_cpu_threads=null num_io_threads=null num_bam_file_handles=null read_group_black_list=null pedigree=[] pedigreeString=[] pedigreeValidationType=STRICT allow_intervals_with_unindexed_bam=false logging_level=INFO log_to_file=null help=false genotype_likelihoods_model=BOTH p_nonref_model=EXACT heterozygosity=0.001 pcr_error_rate=1.0E-4 genotyping_mode=DISCOVERY output_mode=EMIT_VARIANTS_ONLY standard_min_confidence_threshold_for_calling=30.0 standard_min_confidence_threshold_for_emitting=10.0 noSLOD=false annotateNDA=false alleles=(RodBinding name= source=UNBOUND) min_base_quality_score=17 max_deletion_fraction=0.05 max_alternate_alleles=3 min_indel_count_for_genotyping=5 min_indel_fraction_per_sample=0.0 indel_heterozygosity=1.25E-4 indelGapContinuationPenalty=10 indelGapOpenPenalty=45 indelHaplotypeSize=80 noBandedIndel=false indelDebug=false ignoreSNPAlleles=false dbsnp=(RodBinding name= source=UNBOUND) comp=[] out=org.broadinstitute.sting.gatk.io.stubs.VCFWriterStub NO_HEADER=org.broadinstitute.sting.gatk.io.stubs.VCFWriterStub sites_only=org.broadinstitute.sting.gatk.io.stubs.VCFWriterStub debug_file=null metrics_file=null annotation=[] excludeAnnotation=[] filter_mismatching_base_and_quals=false"
+##contig=<ID=1,length=249250621,assembly=b37>
+##contig=<ID=10,length=135534747,assembly=b37>
+##contig=<ID=11,length=135006516,assembly=b37>
+##contig=<ID=12,length=133851895,assembly=b37>
+##contig=<ID=13,length=115169878,assembly=b37>
+##contig=<ID=14,length=107349540,assembly=b37>
+##contig=<ID=15,length=102531392,assembly=b37>
+##contig=<ID=16,length=90354753,assembly=b37>
+##contig=<ID=17,length=81195210,assembly=b37>
+##contig=<ID=18,length=78077248,assembly=b37>
+##contig=<ID=19,length=59128983,assembly=b37>
+##contig=<ID=2,length=243199373,assembly=b37>
+##contig=<ID=20,length=63025520,assembly=b37>
+##contig=<ID=21,length=48129895,assembly=b37>
+##contig=<ID=22,length=51304566,assembly=b37>
+##contig=<ID=3,length=198022430,assembly=b37>
+##contig=<ID=4,length=191154276,assembly=b37>
+##contig=<ID=5,length=180915260,assembly=b37>
+##contig=<ID=6,length=171115067,assembly=b37>
+##contig=<ID=7,length=159138663,assembly=b37>
+##contig=<ID=8,length=146364022,assembly=b37>
+##contig=<ID=9,length=141213431,assembly=b37>
+##contig=<ID=GL000191.1,length=106433,assembly=b37>
+##contig=<ID=GL000192.1,length=547496,assembly=b37>
+##contig=<ID=GL000193.1,length=189789,assembly=b37>
+##contig=<ID=GL000194.1,length=191469,assembly=b37>
+##contig=<ID=GL000195.1,length=182896,assembly=b37>
+##contig=<ID=GL000196.1,length=38914,assembly=b37>
+##contig=<ID=GL000197.1,length=37175,assembly=b37>
+##contig=<ID=GL000198.1,length=90085,assembly=b37>
+##contig=<ID=GL000199.1,length=169874,assembly=b37>
+##contig=<ID=GL000200.1,length=187035,assembly=b37>
+##contig=<ID=GL000201.1,length=36148,assembly=b37>
+##contig=<ID=GL000202.1,length=40103,assembly=b37>
+##contig=<ID=GL000203.1,length=37498,assembly=b37>
+##contig=<ID=GL000204.1,length=81310,assembly=b37>
+##contig=<ID=GL000205.1,length=174588,assembly=b37>
+##contig=<ID=GL000206.1,length=41001,assembly=b37>
+##contig=<ID=GL000207.1,length=4262,assembly=b37>
+##contig=<ID=GL000208.1,length=92689,assembly=b37>
+##contig=<ID=GL000209.1,length=159169,assembly=b37>
+##contig=<ID=GL000210.1,length=27682,assembly=b37>
+##contig=<ID=GL000211.1,length=166566,assembly=b37>
+##contig=<ID=GL000212.1,length=186858,assembly=b37>
+##contig=<ID=GL000213.1,length=164239,assembly=b37>
+##contig=<ID=GL000214.1,length=137718,assembly=b37>
+##contig=<ID=GL000215.1,length=172545,assembly=b37>
+##contig=<ID=GL000216.1,length=172294,assembly=b37>
+##contig=<ID=GL000217.1,length=172149,assembly=b37>
+##contig=<ID=GL000218.1,length=161147,assembly=b37>
+##contig=<ID=GL000219.1,length=179198,assembly=b37>
+##contig=<ID=GL000220.1,length=161802,assembly=b37>
+##contig=<ID=GL000221.1,length=155397,assembly=b37>
+##contig=<ID=GL000222.1,length=186861,assembly=b37>
+##contig=<ID=GL000223.1,length=180455,assembly=b37>
+##contig=<ID=GL000224.1,length=179693,assembly=b37>
+##contig=<ID=GL000225.1,length=211173,assembly=b37>
+##contig=<ID=GL000226.1,length=15008,assembly=b37>
+##contig=<ID=GL000227.1,length=128374,assembly=b37>
+##contig=<ID=GL000228.1,length=129120,assembly=b37>
+##contig=<ID=GL000229.1,length=19913,assembly=b37>
+##contig=<ID=GL000230.1,length=43691,assembly=b37>
+##contig=<ID=GL000231.1,length=27386,assembly=b37>
+##contig=<ID=GL000232.1,length=40652,assembly=b37>
+##contig=<ID=GL000233.1,length=45941,assembly=b37>
+##contig=<ID=GL000234.1,length=40531,assembly=b37>
+##contig=<ID=GL000235.1,length=34474,assembly=b37>
+##contig=<ID=GL000236.1,length=41934,assembly=b37>
+##contig=<ID=GL000237.1,length=45867,assembly=b37>
+##contig=<ID=GL000238.1,length=39939,assembly=b37>
+##contig=<ID=GL000239.1,length=33824,assembly=b37>
+##contig=<ID=GL000240.1,length=41933,assembly=b37>
+##contig=<ID=GL000241.1,length=42152,assembly=b37>
+##contig=<ID=GL000242.1,length=43523,assembly=b37>
+##contig=<ID=GL000243.1,length=43341,assembly=b37>
+##contig=<ID=GL000244.1,length=39929,assembly=b37>
+##contig=<ID=GL000245.1,length=36651,assembly=b37>
+##contig=<ID=GL000246.1,length=38154,assembly=b37>
+##contig=<ID=GL000247.1,length=36422,assembly=b37>
+##contig=<ID=GL000248.1,length=39786,assembly=b37>
+##contig=<ID=GL000249.1,length=38502,assembly=b37>
+##contig=<ID=MT,length=16569,assembly=b37>
+##contig=<ID=X,length=155270560,assembly=b37>
+##contig=<ID=Y,length=59373566,assembly=b37>
+##reference=file:///mnt/research1/reference/human_g1k_v37.fasta
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample
+13	32921034	.	G	A	1057.41	PASS	.	GT	1/1
+13	32921035	.	T	A	1057.41	PASS	.	GT	1/1
+13	32921036	.	A	G	1057.41	PASS	.	GT	1/1
+13	32921041	.	A	G	1057.41	PASS	.	GT	1/1
+13	32921042	.	T	G	1057.41	PASS	.	GT	1/1
+13	32920963	.	G	A	1057.41	PASS	.	GT	1/1
+13	32920962	.	A	T	1057.41	PASS	.	GT	1/1
+13	32920961	.	T	G	1057.41	PASS	.	GT	1/1


### PR DESCRIPTION
Reverts SnpEff to default splicing annotation behavior and bumps version to 1.9.22. Default means 1-2 bases from intron / exon boundary is "splice_acceptor/donor_variant", 3-8 bases away is "splice_region_variant" and more than that is "intron_variant". Also adds some testing code and fixes a different (unrelated) snpeff test