### PR TITLE
Parse the VAL_AF field from VCF records, version 1.9.23

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.aruplab.ngs</groupId>
   <artifactId>Pipeline</artifactId>
   <packaging>jar</packaging>
-  <version>1.9.21</version>
+  <version>1.9.23</version>
   <name>Pipeline</name>
   <url>http://maven.apache.org</url>
   <properties>

--- a/src/main/java/buffer/variant/VariantRec.java
+++ b/src/main/java/buffer/variant/VariantRec.java
@@ -1025,6 +1025,8 @@ public class VariantRec {
    public static final String SV_IMPRECISE = "sv.imprecise";
 
    public static final String MNP_ALLELES = "mnp.alleles";
+   
+   public static final String VAL_AF = "val.af";
 
 
    public static final String PINDEL_ORIG_REF = "pindel.orig.ref";

--- a/src/main/java/pipeline/Pipeline.java
+++ b/src/main/java/pipeline/Pipeline.java
@@ -48,7 +48,7 @@ import util.text.QueuedLogHandler;
  */
 public class Pipeline {
 
-	public static final String PIPELINE_VERSION = "1.9.21";
+	public static final String PIPELINE_VERSION = "1.9.23";
 	protected File source;
 	protected Document xmlDoc;
 	public static final String PROJECT_HOME="home";

--- a/src/main/java/util/vcfParser/VCFParser.java
+++ b/src/main/java/util/vcfParser/VCFParser.java
@@ -582,6 +582,11 @@ public class VCFParser implements VariantLineReader {
 			var.addProperty(VariantRec.RP_SCORE, rpScore);
 		}
 
+		Double valAF = getValAF();
+		if (valAF != null) {
+			var.addProperty(VariantRec.VAL_AF, valAF);
+		}
+		
 		var.addAnnotation(VariantRec.RAW_GT, getSampleMetricsStr("GT"));
 
 		var.addAnnotation(VariantRec.SV_IMPRECISE, getSVImpreciseFlag());
@@ -1194,6 +1199,15 @@ public class VCFParser implements VariantLineReader {
 	}
 	
 	/**
+	 * Parse the VAL_AF field from the variant and return it as a Double
+	 * @return
+	 */
+	public Double getValAF() {
+		String valAF = getSampleMetricsStr("VAL_AF");
+		return convertStr2Double(valAF);
+	}
+	
+	/**
 	 * Returns the genotype sequence alleles 
 	 * @author elainegee
 	 * @return
@@ -1402,3 +1416,5 @@ public class VCFParser implements VariantLineReader {
 	}
 					
 }
+
+	


### PR DESCRIPTION
Just add a single new field to parse from VCF records so we can have the new "validation frequency" stuff passed through