### PR TITLE
Pip 41 parse netlen and insseq

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.aruplab.ngs</groupId>
   <artifactId>Pipeline</artifactId>
   <packaging>jar</packaging>
-  <version>1.9.26</version>
+  <version>1.9.27</version>
   <name>Pipeline</name>
   <url>http://maven.apache.org</url>
   <properties>

--- a/src/main/java/buffer/variant/VariantRec.java
+++ b/src/main/java/buffer/variant/VariantRec.java
@@ -1030,6 +1030,9 @@ public class VariantRec {
    public static final String MEAN_VAL_AF = "mean.val.af";
    public static final String MAX_VAL_AF = "max.val.af";
 
+   public static final String NETLEN = "netlen";
+   public static final String INSSEQ = "insseq";
+
    public static final String PINDEL_ORIG_REF = "pindel.orig.ref";
    public static final String PINDEL_ORIG_ALT = "pindel.orig.alt";
 

--- a/src/main/java/pipeline/Pipeline.java
+++ b/src/main/java/pipeline/Pipeline.java
@@ -48,7 +48,7 @@ import util.text.QueuedLogHandler;
  */
 public class Pipeline {
 
-	public static final String PIPELINE_VERSION = "1.9.26";
+	public static final String PIPELINE_VERSION = "1.9.27";
 	protected File source;
 	protected Document xmlDoc;
 	public static final String PROJECT_HOME="home";

--- a/src/main/java/util/vcfParser/VCFParser.java
+++ b/src/main/java/util/vcfParser/VCFParser.java
@@ -552,6 +552,16 @@ public class VCFParser implements VariantLineReader {
 			}
 		}
 
+                Integer netlen = getNETLEN();
+                if (netlen != null) {
+                        var.addPropertyInt(VariantRec.NETLEN, Math.abs(netlen));
+                }
+
+                String insseq = getINSSEQ();
+                if (insseq != null) {
+                        var.addAnnotation(VariantRec.INSSEQ, insseq);
+                }
+
 		String pindelRef = getPindelRef();
 		if (pindelRef != null) {
 			var.addAnnotation(VariantRec.PINDEL_ORIG_REF, pindelRef);
@@ -1201,7 +1211,35 @@ public class VCFParser implements VariantLineReader {
 		}
 		return svlen;
 	}
-	
+
+        /**
+         * Grabs net length value from VCF, identified by NETLEN field, or null if that key doesn't exist (for Germline and Lofreq variants)
+         * @return netlen (net length of variant)
+         * @author ashinib 
+	 */
+        public int getNETLEN(){
+                if (sampleMetrics.containsKey("NETLEN")) {
+                        String netlen = getSampleMetricsStr("NETLEN");
+                        return convertStr2Int(netlen);
+                } else {
+                       return null;
+                }
+        } 
+
+
+        /**
+         * Return the bases inserted with the 'INSSEQ' field, or null if that key doesn't exist
+         * @return insseq (inserted bases within a DUP or DEL)
+         * @author ashinib            
+         */
+        public String getINSSEQ() {
+                if (sampleMetrics.containsKey("INSSEQ")) {
+                        return sampleMetrics.get("INSSEQ");
+                } else {
+                        return null;
+                }
+        }
+
 	/**
 	 * Grabs the info field END annotation if it exists. If not infoEND (as would be the case for germline), return -1
 	 * @return infoend (end position of structural variant)

--- a/src/main/java/util/vcfParser/VCFParser.java
+++ b/src/main/java/util/vcfParser/VCFParser.java
@@ -552,7 +552,7 @@ public class VCFParser implements VariantLineReader {
 			}
 		}
 
-		Integer netlen = getNETLEN(if (netlen != null) {
+		Integer netlen = getNETLEN();
 		if (netlen != null) {
 			var.addPropertyInt(VariantRec.NETLEN, Math.abs(netlen));
 		}

--- a/src/main/java/util/vcfParser/VCFParser.java
+++ b/src/main/java/util/vcfParser/VCFParser.java
@@ -1217,7 +1217,7 @@ public class VCFParser implements VariantLineReader {
 	 * @return netlen (net length of variant)
 	 * @author ashinib 
 	 */
-	public int getNETLEN(){
+	public Integer getNETLEN(){
 		if (sampleMetrics.containsKey("NETLEN")) {
 			String netlen = getSampleMetricsStr("NETLEN");
 			return convertStr2Int(netlen);

--- a/src/main/java/util/vcfParser/VCFParser.java
+++ b/src/main/java/util/vcfParser/VCFParser.java
@@ -552,15 +552,15 @@ public class VCFParser implements VariantLineReader {
 			}
 		}
 
-                Integer netlen = getNETLEN();
-                if (netlen != null) {
-                        var.addPropertyInt(VariantRec.NETLEN, Math.abs(netlen));
-                }
+		Integer netlen = getNETLEN(if (netlen != null) {
+		if (netlen != null) {
+			var.addPropertyInt(VariantRec.NETLEN, Math.abs(netlen));
+		}
 
-                String insseq = getINSSEQ();
-                if (insseq != null) {
-                        var.addAnnotation(VariantRec.INSSEQ, insseq);
-                }
+		String insseq = getINSSEQ();
+		if (insseq != null) {
+			var.addAnnotation(VariantRec.INSSEQ, insseq);
+		}
 
 		String pindelRef = getPindelRef();
 		if (pindelRef != null) {
@@ -1212,33 +1212,33 @@ public class VCFParser implements VariantLineReader {
 		return svlen;
 	}
 
-        /**
-         * Grabs net length value from VCF, identified by NETLEN field, or null if that key doesn't exist (for Germline and Lofreq variants)
-         * @return netlen (net length of variant)
-         * @author ashinib 
+	/**
+	 * Grabs net length value from VCF, identified by NETLEN field, or null if that key doesn't exist (for Germline and Lofreq variants)
+	 * @return netlen (net length of variant)
+	 * @author ashinib 
 	 */
-        public int getNETLEN(){
-                if (sampleMetrics.containsKey("NETLEN")) {
-                        String netlen = getSampleMetricsStr("NETLEN");
-                        return convertStr2Int(netlen);
-                } else {
-                       return null;
-                }
-        } 
+	public int getNETLEN(){
+		if (sampleMetrics.containsKey("NETLEN")) {
+			String netlen = getSampleMetricsStr("NETLEN");
+			return convertStr2Int(netlen);
+		} else {
+			return null;
+		}
+	} 
 
 
-        /**
-         * Return the bases inserted with the 'INSSEQ' field, or null if that key doesn't exist
-         * @return insseq (inserted bases within a DUP or DEL)
-         * @author ashinib            
-         */
-        public String getINSSEQ() {
-                if (sampleMetrics.containsKey("INSSEQ")) {
-                        return sampleMetrics.get("INSSEQ");
-                } else {
-                        return null;
-                }
-        }
+	/**
+	* Return the bases inserted with the 'INSSEQ' field, or null if that key doesn't exist
+	* @return insseq (inserted bases within a DUP or DEL)
+	* @author ashinib            
+	*/
+	public String getINSSEQ() {
+		if (sampleMetrics.containsKey("INSSEQ")) {
+			return sampleMetrics.get("INSSEQ");
+		} else {
+			return null;
+		}
+	}
 
 	/**
 	 * Grabs the info field END annotation if it exists. If not infoEND (as would be the case for germline), return -1

--- a/src/test/java/testvcfs/netlen_inseq.vcf
+++ b/src/test/java/testvcfs/netlen_inseq.vcf
@@ -1,4 +1,5 @@
-##fileformat=VCFv4.1
+##fileformat=VCFv4.2
+##source=lofreq_scalpel_manta
 ##FILTER=<ID=PASS,Description="All filters passed">
 ##FILTER=<ID=min_dp_10,Description="Minimum Coverage 10">
 ##FILTER=<ID=sb_fdr,Description="Strand-Bias Multiple Testing Correction: fdr corr. pvalue > 0.001000">

--- a/src/test/java/testvcfs/netlen_inseq.vcf
+++ b/src/test/java/testvcfs/netlen_inseq.vcf
@@ -1,16 +1,21 @@
 ##fileformat=VCFv4.1
 ##FILTER=<ID=PASS,Description="All filters passed">
+##FILTER=<ID=min_dp_10,Description="Minimum Coverage 10">
+##FILTER=<ID=sb_fdr,Description="Strand-Bias Multiple Testing Correction: fdr corr. pvalue > 0.001000">
+##FILTER=<ID=min_snvqual_92,Description="Minimum SNV Quality (Phred) 92">
+##FILTER=<ID=min_indelqual_20,Description="Minimum Indel Quality (Phred) 20">
 ##fileDate=20171109
 ##tcgaversion=1.2
 ##reference=human_g1k_v37_decoy_phiXAdaptr
 ##center=""
 ##phasing=none
-##vcfProcessLog=<InputVCF="VALID_171_out_tcga.vcf",InputVCFSource="pindel2vcf",InputVCFVer="0.6.3",InputVCFParam="d=20171109">
-##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
-##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read depth at this position in the sample">
-##FORMAT=<ID=BQ,Number=.,Type=Integer,Description="Average base quality for reads supporting alleles">
-##FORMAT=<ID=SS,Number=1,Type=Integer,Description="Variant status relative to non-adjacent Normal,0=wildtype,1=germline,2=somatic,3=LOH,4=post-transcriptional modification,5=unknown">
-##FORMAT=<ID=AD,Number=.,Type=Integer,Description="Depth of reads supporting alleles 0/1/2/3...">
+##vcfProcessLog=<InputVCF="netlen_inseq.vcf",InputVCFSource="netleninsseqvcf",InputVCFVer="0.0",InputVCFParam="d=20171109">
+##INFO=<ID=AF,Number=1,Type=Float,Description="Allele Frequency">
+##INFO=<ID=SB,Number=1,Type=Integer,Description="Phred-scaled strand bias at this position">
+##INFO=<ID=DP4,Number=4,Type=Integer,Description="Counts for ref-forward bases, ref-reverse, alt-forward and alt-reverse bases">
+##INFO=<ID=INDEL,Number=0,Type=Flag,Description="Indicates that the variant is an INDEL.">
+##INFO=<ID=CONSVAR,Number=0,Type=Flag,Description="Indicates that the variant is a consensus variant (as opposed to a low frequency variant).">
+##INFO=<ID=HRUN,Number=1,Type=Integer,Description="Homopolymer length to the right of report indel position">
 ##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the variant described in this record">
 ##INFO=<ID=HOMLEN,Number=.,Type=Integer,Description="Length of base pair identical micro-homology at event breakpoints">
 ##INFO=<ID=PF,Number=1,Type=Integer,Description="The number of samples carry the variant">
@@ -18,14 +23,21 @@
 ##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Difference in length between REF and ALT alleles">
 ##INFO=<ID=TYPEOFSV,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=NTLEN,Number=.,Type=Integer,Description="Number of bases inserted in place of deleted code">
-##FORMAT=<ID=PL,Number=3,Type=Integer,Description="Normalized, Phred-scaled likelihoods for AA,AB,BB genotypes where A=ref and B=alt; not applicable if site is not biallelic">
-##INFO=<ID=AF,Number=1,Type=Float,Description="Allele Frequency">
 ##INFO=<ID=orig_ref,Number=1,Type=String,Description="Original REF sequence">
 ##INFO=<ID=orig_alt,Number=1,Type=String,Description="Original ALT sequence">
 ##INFO=<ID=set,Number=1,Type=String,Description="Source VCF for the merged record in CombineVariants">
 ##INFO=<ID=NETLEN,Number=.,Type=Integer,Description="Net length of insertion and duplication or deletion and insertion">
 ##INFO=<ID=INSSEQ,Number=.,Type=String,Description="Inserted sequence between duplication or in place of a deletion">
+##FORMAT=<ID=DP4,Number=4,Type=Integer,Description="Counts for ref-forward bases, ref-reverse, alt-forward and alt-reverse bases">
+##FORMAT=<ID=AF,Number=1,Type=Float,Description="Allele Frequency">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read depth at this position in the sample">
+##FORMAT=<ID=BQ,Number=.,Type=Integer,Description="Average base quality for reads supporting alleles">
+##FORMAT=<ID=SS,Number=1,Type=Integer,Description="Variant status relative to non-adjacent Normal,0=wildtype,1=germline,2=somatic,3=LOH,4=post-transcriptional modification,5=unknown">
+##FORMAT=<ID=AD,Number=.,Type=Integer,Description="Depth of reads supporting alleles 0/1/2/3...">
+##FORMAT=<ID=PL,Number=3,Type=Integer,Description="Normalized, Phred-scaled likelihoods for AA,AB,BB genotypes where A=ref and B=alt; not applicable if site is not biallelic">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	test
+1	843405	.	A	G	25622	PASS	DP=2588;AF=0.414606;SB=0;DP4=731,762,528,561;set=lofreq	GT:AF:DP4	0/1:0.414606:731,762,528,561
 13	28608094	.	C	<DUP:TANDEM>	.	PASS	END=28608187;HOMLEN=0;SVLEN=93;TYPEOFSV=DUP:TANDEM;NTLEN=93;orig_ref=CACTTTTCCAAAAGCACCTGATCCTAGTACCTTCCCTGCAAAGACAAATGGTGAGTACGTGCATTTTAAAGATTTTCCAATGGAAAAGAAATGC;orig_alt=CACTTTTCCAAAAGCACCTGATCCTAGTACCTTCCCTGCAAAGACAAATGGTGAGTACGTGCATTTTAAAGATTTTCCAATGGAAAAGAAATGCGTCAGAAAAATTTGGCACATTACATTCTTACAAAACTATAACTTTTCTCTTGGAAAATCCCATTTGAGATCATATTCATATTCTCTGAAGCTTACTTTTCCAAAAGCACCTGATCCTAGTACCTTCCCTGCAAAGACAAATGGTGAGTACGTGCATTTTAAAGATTTTCCAATGGAAAAGAAATGC;AF=0;set=pindel;NETLEN=186;INSSEQ=GTCAGAAAAATTTGGCACATTACATTCTTACAAAACTATAACTTTTCTCTTGGAAAATCCCATTTGAGATCATATTCATATTCTCTGAAGCTT	GT:DP:BQ:SS:AD	0/0:2594:.:2:2593,1
 13	28608275	.	AAATCAACGTA	AT	.	PASS	END=28608285;HOMLEN=0;SVLEN=-10;TYPEOFSV=RPL;NTLEN=1;orig_ref=AAATCAACGTA;orig_alt=AT;AF=0.003;set=pindel;NETLEN=-9;INSSEQ=T	GT:DP:BQ:SS:AD	0/0:1167:.:2:1164,3
 13	28608282	.	C	<DEL>	.	PASS	END=28608288;HOMLEN=3;HOMSEQ=GTA;SVLEN=-6;TYPEOFSV=DEL;orig_ref=CGTAGAA;orig_alt=C;AF=0.001;set=pindel;NETLEN=-6	GT:DP:BQ:SS:AD	0/0:1110:.:2:1109,1

--- a/src/test/java/testvcfs/netlen_inseq.vcf
+++ b/src/test/java/testvcfs/netlen_inseq.vcf
@@ -1,0 +1,31 @@
+##fileformat=VCFv4.1
+##FILTER=<ID=PASS,Description="All filters passed">
+##fileDate=20171109
+##tcgaversion=1.2
+##reference=human_g1k_v37_decoy_phiXAdaptr
+##center=""
+##phasing=none
+##vcfProcessLog=<InputVCF="VALID_171_out_tcga.vcf",InputVCFSource="pindel2vcf",InputVCFVer="0.6.3",InputVCFParam="d=20171109">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read depth at this position in the sample">
+##FORMAT=<ID=BQ,Number=.,Type=Integer,Description="Average base quality for reads supporting alleles">
+##FORMAT=<ID=SS,Number=1,Type=Integer,Description="Variant status relative to non-adjacent Normal,0=wildtype,1=germline,2=somatic,3=LOH,4=post-transcriptional modification,5=unknown">
+##FORMAT=<ID=AD,Number=.,Type=Integer,Description="Depth of reads supporting alleles 0/1/2/3...">
+##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the variant described in this record">
+##INFO=<ID=HOMLEN,Number=.,Type=Integer,Description="Length of base pair identical micro-homology at event breakpoints">
+##INFO=<ID=PF,Number=1,Type=Integer,Description="The number of samples carry the variant">
+##INFO=<ID=HOMSEQ,Number=.,Type=String,Description="Sequence of base pair identical micro-homology at event breakpoints">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Difference in length between REF and ALT alleles">
+##INFO=<ID=TYPEOFSV,Number=1,Type=String,Description="Type of structural variant">
+##INFO=<ID=NTLEN,Number=.,Type=Integer,Description="Number of bases inserted in place of deleted code">
+##FORMAT=<ID=PL,Number=3,Type=Integer,Description="Normalized, Phred-scaled likelihoods for AA,AB,BB genotypes where A=ref and B=alt; not applicable if site is not biallelic">
+##INFO=<ID=AF,Number=1,Type=Float,Description="Allele Frequency">
+##INFO=<ID=orig_ref,Number=1,Type=String,Description="Original REF sequence">
+##INFO=<ID=orig_alt,Number=1,Type=String,Description="Original ALT sequence">
+##INFO=<ID=set,Number=1,Type=String,Description="Source VCF for the merged record in CombineVariants">
+##INFO=<ID=NETLEN,Number=.,Type=Integer,Description="Net length of insertion and duplication or deletion and insertion">
+##INFO=<ID=INSSEQ,Number=.,Type=String,Description="Inserted sequence between duplication or in place of a deletion">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	test
+13	28608094	.	C	<DUP:TANDEM>	.	PASS	END=28608187;HOMLEN=0;SVLEN=93;TYPEOFSV=DUP:TANDEM;NTLEN=93;orig_ref=CACTTTTCCAAAAGCACCTGATCCTAGTACCTTCCCTGCAAAGACAAATGGTGAGTACGTGCATTTTAAAGATTTTCCAATGGAAAAGAAATGC;orig_alt=CACTTTTCCAAAAGCACCTGATCCTAGTACCTTCCCTGCAAAGACAAATGGTGAGTACGTGCATTTTAAAGATTTTCCAATGGAAAAGAAATGCGTCAGAAAAATTTGGCACATTACATTCTTACAAAACTATAACTTTTCTCTTGGAAAATCCCATTTGAGATCATATTCATATTCTCTGAAGCTTACTTTTCCAAAAGCACCTGATCCTAGTACCTTCCCTGCAAAGACAAATGGTGAGTACGTGCATTTTAAAGATTTTCCAATGGAAAAGAAATGC;AF=0;set=pindel;NETLEN=186;INSSEQ=GTCAGAAAAATTTGGCACATTACATTCTTACAAAACTATAACTTTTCTCTTGGAAAATCCCATTTGAGATCATATTCATATTCTCTGAAGCTT	GT:DP:BQ:SS:AD	0/0:2594:.:2:2593,1
+13	28608275	.	AAATCAACGTA	AT	.	PASS	END=28608285;HOMLEN=0;SVLEN=-10;TYPEOFSV=RPL;NTLEN=1;orig_ref=AAATCAACGTA;orig_alt=AT;AF=0.003;set=pindel;NETLEN=-9;INSSEQ=T	GT:DP:BQ:SS:AD	0/0:1167:.:2:1164,3
+13	28608282	.	C	<DEL>	.	PASS	END=28608288;HOMLEN=3;HOMSEQ=GTA;SVLEN=-6;TYPEOFSV=DEL;orig_ref=CGTAGAA;orig_alt=C;AF=0.001;set=pindel;NETLEN=-6	GT:DP:BQ:SS:AD	0/0:1110:.:2:1109,1

--- a/src/test/java/vcfLineParser/TestVCFParser.java
+++ b/src/test/java/vcfLineParser/TestVCFParser.java
@@ -1390,6 +1390,7 @@ public class TestVCFParser {
 		
 		System.err.println("\tVCFLineParser tests passed on Netlen and Inseq VCF ....");
 
+     }
 }
 	
 

--- a/src/test/java/vcfLineParser/TestVCFParser.java
+++ b/src/test/java/vcfLineParser/TestVCFParser.java
@@ -1228,7 +1228,7 @@ public class TestVCFParser {
 		
 				String genotype = parserGT.getGT();
 				Assert.assertTrue(genotype.equals("./-"));
-				
+G				
 				GTType hetero = parserGT.isHetero();
 				Assert.assertTrue(hetero == GTType.HET);
                         } else if (i == 7) {
@@ -1367,26 +1367,26 @@ public class TestVCFParser {
 		Assert.assertTrue(vars.size() == 4);
 
 		// Both "NETLEN" and INSSEQ for first variant should be null
-		Integer net_len = vars.get(0).getProperty("netlen");
+		Integer net_len = vars.get(0).getPropertyInt("netlen");
 		Assert.assertTrue(net_len == null);
 
-		String ins_seq = vars.get(0).getProperty("insseq");
+		String ins_seq = vars.get(0).getAnnotation("insseq");
 		Assert.assertTrue(ins_seq == null);
 	
 		// Check Net Length and Inserted sequence values for second variant
-		Integer net_len = vars.get(1).getProperty("netlen");
+		Integer net_len = vars.get(1).getPropertyInt("netlen");
 		Assert.assertTrue(net_len == 186);
 	
-		String ins_seq = vars.get(1).getProperty("insseq");
+		String ins_seq = vars.get(1).getAnnotation("insseq");
 		Assert.assertTrue(ins_seq == "GTCAGAAAAATTTGGCACATTACATTCTTACAAAACTATAACTTTTCTCTTGGAAAATCCCATTTGAGATCATATTCATATTCTCTGAAGCTT");
 
 		// Check Both Netlen and Insseq for third variant
-		Assert.assertTrue(vars.get(2).getProperty("netlen") == 9);
-		Assert.assertTrue(vars.get(2).getProperty("ins_seq") == "T");
+		Assert.assertTrue(vars.get(2).getPropertyInt("netlen") == 9);
+		Assert.assertTrue(vars.get(2).getAnnotation("ins_seq") == "T");
 
 		// Insseq should be null and Netlen not a null value for this fourth variant
-		Assert.assertTrue(vars.get(3).getProperty("netlen") == 6);
-		Assert.assertTrue(vars.get(3).getProperty("ins_seq") == null);
+		Assert.assertTrue(vars.get(3).getPropertyInt("netlen") == 6);
+		Assert.assertTrue(vars.get(3).getAnnotation("ins_seq") == null);
 		
 		System.err.println("\tVCFLineParser tests passed on Netlen and Inseq VCF ....");
 

--- a/src/test/java/vcfLineParser/TestVCFParser.java
+++ b/src/test/java/vcfLineParser/TestVCFParser.java
@@ -1364,23 +1364,29 @@ public class TestVCFParser {
 			VariantRec var = parser.toVariantRec();
 			vars.add(var);
 		}
-		Assert.assertTrue(vars.size() == 3);
+		Assert.assertTrue(vars.size() == 4);
 
-		// Check Net Length: "NETLEN" for first variant
+		// Both "NETLEN" and INSSEQ for first variant should be null
 		Integer net_len = vars.get(0).getProperty("netlen");
+		Assert.assertTrue(net_len == null);
+
+		String ins_seq = vars.get(0).getProperty("insseq");
+		Assert.assertTrue(ins_seq == null);
+	
+		// Check Net Length and Inserted sequence values for second variant
+		Integer net_len = vars.get(1).getProperty("netlen");
 		Assert.assertTrue(net_len == 186);
 	
-		// Check Inserted Sequence: "INSSEQ" for first variant
-		String ins_seq = vars.get(0).getProperty("insseq");
+		String ins_seq = vars.get(1).getProperty("insseq");
 		Assert.assertTrue(ins_seq == "GTCAGAAAAATTTGGCACATTACATTCTTACAAAACTATAACTTTTCTCTTGGAAAATCCCATTTGAGATCATATTCATATTCTCTGAAGCTT");
 
-		// Check Both Netlen and Insseq for second variant
-		Assert.assertTrue(vars.get(1).getProperty("netlen") == 9);
-		Assert.assertTrue(vars.get(1).getProperty("ins_seq") == "T");
+		// Check Both Netlen and Insseq for third variant
+		Assert.assertTrue(vars.get(2).getProperty("netlen") == 9);
+		Assert.assertTrue(vars.get(2).getProperty("ins_seq") == "T");
 
-		// Insseq should be null and Netlen not a null value for this variant
-		Assert.assertTrue(vars.get(2).getProperty("netlen") == 6);
-		Assert.assertTrue(vars.get(1).getProperty("ins_seq") == null);
+		// Insseq should be null and Netlen not a null value for this fourth variant
+		Assert.assertTrue(vars.get(3).getProperty("netlen") == 6);
+		Assert.assertTrue(vars.get(3).getProperty("ins_seq") == null);
 		
 		System.err.println("\tVCFLineParser tests passed on Netlen and Inseq VCF ....");
 

--- a/src/test/java/vcfLineParser/TestVCFParser.java
+++ b/src/test/java/vcfLineParser/TestVCFParser.java
@@ -1375,7 +1375,6 @@ public class TestVCFParser {
 
 		// Check Net Length and Inserted sequence values for second variant
 		Assert.assertTrue(vars.get(1).getPropertyInt("netlen") == 186);
-		System.err.println(vars.get(1).getAnnotation("insseq") + "ashini");
 		Assert.assertTrue(vars.get(1).getAnnotation("insseq").equals("GTCAGAAAAATTTGGCACATTACATTCTTACAAAACTATAACTTTTCTCTTGGAAAATCCCATTTGAGATCATATTCATATTCTCTGAAGCTT"));
 
 		// Check Both Netlen and Insseq for third variant

--- a/src/test/java/vcfLineParser/TestVCFParser.java
+++ b/src/test/java/vcfLineParser/TestVCFParser.java
@@ -1228,7 +1228,7 @@ public class TestVCFParser {
 		
 				String genotype = parserGT.getGT();
 				Assert.assertTrue(genotype.equals("./-"));
-G				
+	
 				GTType hetero = parserGT.isHetero();
 				Assert.assertTrue(hetero == GTType.HET);
                         } else if (i == 7) {
@@ -1372,21 +1372,19 @@ G
 
 		String ins_seq = vars.get(0).getAnnotation("insseq");
 		Assert.assertTrue(ins_seq == null);
-	
+
 		// Check Net Length and Inserted sequence values for second variant
-		Integer net_len = vars.get(1).getPropertyInt("netlen");
-		Assert.assertTrue(net_len == 186);
-	
-		String ins_seq = vars.get(1).getAnnotation("insseq");
-		Assert.assertTrue(ins_seq == "GTCAGAAAAATTTGGCACATTACATTCTTACAAAACTATAACTTTTCTCTTGGAAAATCCCATTTGAGATCATATTCATATTCTCTGAAGCTT");
+		Assert.assertTrue(vars.get(1).getPropertyInt("netlen") == 186);
+		System.err.println(vars.get(1).getAnnotation("insseq") + "ashini");
+		Assert.assertTrue(vars.get(1).getAnnotation("insseq").equals("GTCAGAAAAATTTGGCACATTACATTCTTACAAAACTATAACTTTTCTCTTGGAAAATCCCATTTGAGATCATATTCATATTCTCTGAAGCTT"));
 
 		// Check Both Netlen and Insseq for third variant
 		Assert.assertTrue(vars.get(2).getPropertyInt("netlen") == 9);
-		Assert.assertTrue(vars.get(2).getAnnotation("ins_seq") == "T");
+		Assert.assertTrue(vars.get(2).getAnnotation("insseq").equals("T"));
 
 		// Insseq should be null and Netlen not a null value for this fourth variant
 		Assert.assertTrue(vars.get(3).getPropertyInt("netlen") == 6);
-		Assert.assertTrue(vars.get(3).getAnnotation("ins_seq") == null);
+		Assert.assertTrue(vars.get(3).getAnnotation("insseq") == null);
 		
 		System.err.println("\tVCFLineParser tests passed on Netlen and Inseq VCF ....");
 

--- a/src/test/java/vcfLineParser/TestVCFParser.java
+++ b/src/test/java/vcfLineParser/TestVCFParser.java
@@ -40,6 +40,8 @@ public class TestVCFParser {
 
         File valafVCF = new File("src/test/java/testvcfs/validation_vaf.vcf");
 	
+	File netlenVCF = new File("src/test/java/testvcfs/netlen_inseq.vcf");
+
 	@Test (expected = IOException.class)
 	public void TestEmptyHeader() throws IOException {
 		System.out.println("VCFParser tests on parsing header:");
@@ -1350,6 +1352,37 @@ public class TestVCFParser {
 		System.err.println("\tVCFLineParser tests passed on Lithium Filtered VCF.");
 
      }
+
+	// Test single sample with netlen and insseq keys
+        @Test
+	public void TestNetlenInsseqVCF() throws IOException {
+		System.err.println("Testing VCFLineParser: Netlen and Insseq VCF ...");
+		
+		VCFParser parser = new VCFParser(netlenVCF);
+		List<VariantRec> vars = new ArrayList<VariantRec>();
+		while(parser.advanceLine()) {
+			VariantRec var = parser.toVariantRec();
+			vars.add(var);
+		}
+		Assert.assertTrue(vars.size() == 3);
+
+		// Check Net Length: "NETLEN" for first variant
+		Integer net_len = vars.get(0).getProperty("netlen");
+		Assert.assertTrue(net_len == 186);
+	
+		// Check Inserted Sequence: "INSSEQ" for first variant
+		String ins_seq = vars.get(0).getProperty("insseq");
+		Assert.assertTrue(ins_seq == "GTCAGAAAAATTTGGCACATTACATTCTTACAAAACTATAACTTTTCTCTTGGAAAATCCCATTTGAGATCATATTCATATTCTCTGAAGCTT");
+
+		// Check Both Netlen and Insseq for second variant
+		Assert.assertTrue(vars.get(1).getProperty("netlen") == 9);
+		Assert.assertTrue(vars.get(1).getProperty("ins_seq") == "T");
+
+		// Insseq should be null and Netlen not a null value for this variant
+		Assert.assertTrue(vars.get(2).getProperty("netlen") == 6);
+		Assert.assertTrue(vars.get(1).getProperty("ins_seq") == null);
+		
+		System.err.println("\tVCFLineParser tests passed on Netlen and Inseq VCF ....");
 
 }
 	


### PR DESCRIPTION
For Somatic samples, VCF files will be annotated with NETLEN and INSSEQ key for few variants, Pipeline.jar needs to be updated to parse the value of these two fields in the VCF and populate these in the annotated JSON file.
The pipeline.jar file is here:
/Reference/aws/prd/Apps/Pipeline/1.9.27/pipeline.jar